### PR TITLE
Ergonomic CLI commands

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -40240,7 +40240,7 @@ which.sync = whichSync
 
 /***/ }),
 
-/***/ 7931:
+/***/ 3129:
 /***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
 
@@ -42085,7 +42085,7 @@ async function getCurrentTarget(log) {
     return target;
 }
 
-;// CONCATENATED MODULE: ./src/commands/add-platform.ts
+;// CONCATENATED MODULE: ./src/commands/add.ts
 
 
 
@@ -42093,16 +42093,16 @@ async function getCurrentTarget(log) {
 function optionArray(option) {
     return option == null ? [] : [option];
 }
-const add_platform_OPTIONS = [
+const add_OPTIONS = [
     { name: 'os', type: String, defaultValue: null },
     { name: 'arch', type: String, defaultValue: null },
     { name: 'abi', type: String, defaultValue: null },
     { name: 'out-dir', alias: 'o', type: String, defaultValue: 'platforms' },
     { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
 ];
-class AddPlatform {
+class Add {
     static summary() { return 'Add a platform or platform preset to a Neon project.'; }
-    static syntax() { return 'neon add-platform [<p> | --os <a> --arch <b> [--abi <c>]] [-o <d>] [-b <f>]'; }
+    static syntax() { return 'neon add [<p> | --os <a> --arch <b> [--abi <c>]] [-o <d>] [-b <f>]'; }
     static options() {
         return [
             { name: '<p>', summary: 'A Node platform or platform preset.' },
@@ -42139,7 +42139,7 @@ class AddPlatform {
     _outDir;
     _verbose;
     constructor(argv) {
-        const options = dist_default()(add_platform_OPTIONS, { argv, partial: true });
+        const options = dist_default()(add_OPTIONS, { argv, partial: true });
         this._os = options.os || null;
         this._arch = options.arch || null;
         this._abi = options.abi || null;
@@ -42169,7 +42169,7 @@ class AddPlatform {
     }
     log(msg) {
         if (this._verbose) {
-            console.error("[neon add-platform] " + msg);
+            console.error("[neon add] " + msg);
         }
     }
     async addPlatform(libManifest) {
@@ -42204,34 +42204,30 @@ class AddPlatform {
     }
 }
 
-;// CONCATENATED MODULE: ./src/commands/update-platforms.ts
+;// CONCATENATED MODULE: ./src/commands/update.ts
 
 
-const update_platforms_OPTIONS = [
+const update_OPTIONS = [
     { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
 ];
-class UpdatePlatforms {
+class Update {
     static summary() { return 'Update configuration for all build platforms in package.json.'; }
-    static syntax() { return 'neon update-platforms [-b <file>]'; }
+    static syntax() { return 'neon update [-v]'; }
     static options() {
         return [
             { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' }
         ];
     }
-    static seeAlso() {
-        return [
-            { name: 'ncc', summary: '<https://github.com/vercel/ncc>' }
-        ];
-    }
+    static seeAlso() { }
     static extraSection() { }
     _verbose;
     constructor(argv) {
-        const options = dist_default()(update_platforms_OPTIONS, { argv });
+        const options = dist_default()(update_OPTIONS, { argv });
         this._verbose = !!options.verbose;
     }
     log(msg) {
         if (this._verbose) {
-            console.error("[neon update-platforms] " + msg);
+            console.error("[neon update] " + msg);
         }
     }
     async run() {
@@ -42495,6 +42491,8 @@ var CommandName;
     CommandName["Help"] = "help";
     CommandName["Dist"] = "dist";
     CommandName["Bump"] = "bump";
+    CommandName["Add"] = "add";
+    CommandName["Update"] = "update";
     CommandName["AddPlatform"] = "add-platform";
     CommandName["UpdatePlatforms"] = "update-platforms";
     CommandName["ListPlatforms"] = "list-platforms";
@@ -42518,8 +42516,10 @@ const COMMANDS = {
     [CommandName.Help]: Help,
     [CommandName.Dist]: Dist,
     [CommandName.Bump]: Bump,
-    [CommandName.AddPlatform]: AddPlatform,
-    [CommandName.UpdatePlatforms]: UpdatePlatforms,
+    [CommandName.Add]: Add,
+    [CommandName.Update]: Update,
+    [CommandName.AddPlatform]: Add,
+    [CommandName.UpdatePlatforms]: Update,
     [CommandName.ListPlatforms]: ListPlatforms,
     [CommandName.CurrentPlatform]: CurrentPlatform,
     [CommandName.Preset]: Preset,
@@ -42534,8 +42534,8 @@ function summaries() {
         { name: CommandName.Help, summary: Help.summary() },
         { name: CommandName.Dist, summary: Dist.summary() },
         { name: CommandName.Bump, summary: Bump.summary() },
-        { name: CommandName.AddPlatform, summary: AddPlatform.summary() },
-        { name: CommandName.UpdatePlatforms, summary: UpdatePlatforms.summary() },
+        { name: CommandName.Add, summary: Add.summary() },
+        { name: CommandName.Update, summary: Update.summary() },
         { name: CommandName.Show, summary: show/* default.summary */.ZP.summary() }
     ];
 }
@@ -42849,7 +42849,7 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 /* harmony import */ var command_line_commands__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(5046);
 /* harmony import */ var command_line_commands__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(command_line_commands__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _print_js__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(9050);
-/* harmony import */ var _command_js__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(7931);
+/* harmony import */ var _command_js__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(3129);
 /* harmony import */ var node_module__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(2033);
 /* harmony import */ var node_module__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__nccwpck_require__.n(node_module__WEBPACK_IMPORTED_MODULE_3__);
 
@@ -45879,7 +45879,7 @@ const chalkStderr = createChalk({level: stderrColor ? stderrColor.level : 0});
 /* harmony default export */ const chalk_source = (chalk);
 
 // EXTERNAL MODULE: ./src/command.ts + 35 modules
-var command = __nccwpck_require__(7931);
+var command = __nccwpck_require__(3129);
 // EXTERNAL MODULE: ./src/commands/show.ts + 4 modules
 var show = __nccwpck_require__(6264);
 ;// CONCATENATED MODULE: ./src/print.ts

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -45905,7 +45905,7 @@ function purple(text) {
 function commandUsage(name, command) {
     const sections = [
         {
-            content: `${pink('Neon:')} ${name} - ${command.summary()}`,
+            content: `${pink('neon ' + name)} - ${command.summary()}`,
             raw: true
         },
         {
@@ -45930,7 +45930,7 @@ function commandUsage(name, command) {
 function mainUsage() {
     const sections = [
         {
-            content: `${pink('Neon:')} the npm packaging tool for Rust addons`,
+            content: `${pink('neon')} - manage and distribute Neon projects`,
             raw: true
         },
         {
@@ -45945,7 +45945,7 @@ function mainUsage() {
     return command_line_usage(sections).trim();
 }
 function printShowTopicUsage(topic) {
-    console.error(commandUsage(topic, (0,show/* subcommandFor */.D8)(topic)));
+    console.error(commandUsage("show " + topic, (0,show/* subcommandFor */.D8)(topic)));
 }
 function printCommandUsage(name) {
     console.error(commandUsage(name, (0,command/* commandFor */.Nl)(name)));

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -40240,7 +40240,7 @@ which.sync = whichSync
 
 /***/ }),
 
-/***/ 3149:
+/***/ 7931:
 /***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
 
 
@@ -40266,16 +40266,10 @@ var lib = __nccwpck_require__(3993);
 ;// CONCATENATED MODULE: ./node_modules/cargo-messages/lib/index.mjs
 
 
-// EXTERNAL MODULE: ../node_modules/@neon-rs/manifest/lib/index.cjs
-var manifest_lib = __nccwpck_require__(4696);
-;// CONCATENATED MODULE: ../node_modules/@neon-rs/manifest/lib/index.mjs
-
-
-// EXTERNAL MODULE: ../node_modules/@neon-rs/manifest/lib/platform.cjs
-var lib_platform = __nccwpck_require__(2147);
-;// CONCATENATED MODULE: ../node_modules/@neon-rs/manifest/lib/platform.mjs
-
-
+// EXTERNAL MODULE: ../node_modules/@neon-rs/manifest/lib/index.mjs
+var manifest_lib = __nccwpck_require__(347);
+// EXTERNAL MODULE: ../node_modules/@neon-rs/manifest/lib/platform.mjs
+var lib_platform = __nccwpck_require__(8140);
 ;// CONCATENATED MODULE: ./src/commands/dist.ts
 
 
@@ -40323,7 +40317,7 @@ function parseOutputFile(debug, out, platform) {
     const NEON_BUILD_PLATFORM = process.env['NEON_BUILD_PLATFORM'];
     if (platform || (!debug && NEON_BUILD_PLATFORM)) {
         const p = platform || NEON_BUILD_PLATFORM;
-        (0,lib_platform.assertIsNodePlatform)(p);
+        (0,lib_platform/* assertIsNodePlatform */.or)(p);
         return manifest_lib/* LibraryManifest.load */.N.load().then(manifest => {
             const path = manifest.getPlatformOutputPath(p);
             if (!path) {
@@ -42087,7 +42081,7 @@ async function getCurrentTarget(log) {
     }
     const target = hostLine.replace(/^host:\s+/, '');
     log(`currentTarget result: "${target}"`);
-    (0,lib_platform.assertIsRustTarget)(target);
+    (0,lib_platform/* assertIsRustTarget */.sD)(target);
     return target;
 }
 
@@ -42183,15 +42177,15 @@ class AddPlatform {
             this.log('adding default system platform');
             await libManifest.addRustTarget(await getCurrentTarget(msg => this.log(msg)));
         }
-        else if ((0,lib_platform.isRustTarget)(this._platform)) {
+        else if ((0,lib_platform/* isRustTarget */.FZ)(this._platform)) {
             this.log(`adding Rust target ${this._platform}`);
             await libManifest.addRustTarget(this._platform);
         }
-        else if ((0,lib_platform.isNodePlatform)(this._platform)) {
+        else if ((0,lib_platform/* isNodePlatform */.bC)(this._platform)) {
             this.log(`adding Node platform ${this._platform}`);
             await libManifest.addNodePlatform(this._platform);
         }
-        else if ((0,lib_platform.isPlatformPreset)(this._platform)) {
+        else if ((0,lib_platform/* isPlatformPreset */.Qm)(this._platform)) {
             await libManifest.addPlatformPreset(this._platform);
         }
         else {
@@ -42365,7 +42359,7 @@ class Preset {
         if (options._unknown.length > 1) {
             throw new Error(`Unexpected argument ${options._unknown[1]}`);
         }
-        (0,lib_platform.assertIsPlatformPreset)(options._unknown[0]);
+        (0,lib_platform/* assertIsPlatformPreset */.Zv)(options._unknown[0]);
         this._preset = options._unknown[0];
     }
     log(msg) {
@@ -42374,73 +42368,13 @@ class Preset {
         }
     }
     async run() {
-        const map = (0,lib_platform.expandPlatformPreset)(this._preset);
+        const map = (0,lib_platform/* expandPlatformPreset */.EY)(this._preset);
         console.log(JSON.stringify(map, null, 2));
     }
 }
 
-;// CONCATENATED MODULE: ./data/github.json
-const github_namespaceObject = JSON.parse('{"darwin-arm64":"macOS","darwin-x64":"macOS","ios-arm64":null,"ios-x64":null,"android-arm64":"Linux","android-arm-eabi":"Linux","android-ia32":null,"android-x64":"Linux","win32-arm64-msvc":"Windows","win32-ia32-gnu":null,"win32-ia32-msvc":null,"win32-x64-gnu":null,"win32-x64-msvc":"Windows","linux-arm64-gnu":"Linux","linux-arm64-musl":null,"linux-arm-gnueabihf":"Linux","linux-arm-musleabihf":null,"linux-ia32-gnu":null,"linux-ia32-musl":null,"linux-mips-gnu":null,"linux-mips-musl":null,"linux-mips64-gnuabi64":null,"linux-mips64-muslabi64":null,"linux-mips64el-gnuabi64":null,"linux-mips64el-muslabi64":null,"linux-mipsel-gnu":null,"linux-mipsel-musl":null,"linux-powerpc-gnu":null,"linux-powerpc64-gnu":null,"linux-powerpc64le-gnu":null,"linux-riscv64gc-gnu":null,"linux-s390x-gnu":null,"linux-sparc64-gnu":null,"linux-x64-gnu":"Linux","linux-x64-gnux32":null,"linux-x64-musl":null,"freebsd-ia32":null,"freebsd-x64":null}');
-;// CONCATENATED MODULE: ./src/ci/github.ts
-
-function sort(platforms) {
-    const macOS = new Set();
-    const Windows = new Set();
-    const Linux = new Set();
-    const unsupported = new Set();
-    for (const platform of platforms) {
-        switch (github_namespaceObject[platform]) {
-            case 'macOS':
-                macOS.add(platform);
-                break;
-            case 'Windows':
-                Windows.add(platform);
-                break;
-            case 'Linux':
-                Linux.add(platform);
-                break;
-            default:
-                unsupported.add(platform);
-                break;
-        }
-    }
-    return {
-        macOS: [...macOS],
-        Windows: [...Windows],
-        Linux: [...Linux],
-        unsupported: [...unsupported]
-    };
-}
-class GitHub {
-    metadata(platforms) {
-        return sort(Object.keys(platforms));
-    }
-}
-
-;// CONCATENATED MODULE: ./src/provider.ts
-
-var ProviderName;
-(function (ProviderName) {
-    ProviderName["GitHub"] = "github";
-})(ProviderName || (ProviderName = {}));
-;
-const PROVIDERS = {
-    [ProviderName.GitHub]: GitHub
-};
-function isProviderName(s) {
-    const keys = Object.values(ProviderName);
-    return keys.includes(s);
-}
-function asProviderName(name) {
-    if (!isProviderName(name)) {
-        throw new RangeError(`CI provider not recognized: ${name}`);
-    }
-    return name;
-}
-function providerFor(name) {
-    return PROVIDERS[name];
-}
-
+// EXTERNAL MODULE: ./src/provider.ts + 2 modules
+var provider = __nccwpck_require__(545);
 ;// CONCATENATED MODULE: ./src/commands/ci.ts
 
 
@@ -42478,8 +42412,8 @@ class Ci {
         if (!options._unknown || options._unknown.length === 0) {
             throw new Error("No arguments found, expected <provider>.");
         }
-        const providerName = asProviderName(options._unknown[0]);
-        const providerCtor = providerFor(providerName);
+        const providerName = (0,provider/* asProviderName */.tb)(options._unknown[0]);
+        const providerCtor = (0,provider/* providerFor */.kq)(providerName);
         this._provider = new providerCtor();
     }
     log(msg) {
@@ -42499,7 +42433,10 @@ class Ci {
 
 // EXTERNAL MODULE: ./src/print.ts + 26 modules
 var print = __nccwpck_require__(9050);
+// EXTERNAL MODULE: ./src/commands/show.ts + 4 modules
+var show = __nccwpck_require__(6264);
 ;// CONCATENATED MODULE: ./src/commands/help.ts
+
 
 
 class Help {
@@ -42513,14 +42450,27 @@ class Help {
     static seeAlso() { }
     static extraSection() { }
     _name;
+    _topic;
     constructor(argv) {
         this._name = argv.length > 0 ? asCommandName(argv[0]) : undefined;
-        if (argv.length > 1) {
+        this._topic = undefined;
+        if (this._name === CommandName.Show) {
+            if (argv.length === 2) {
+                this._topic = (0,show/* asTopic */.sY)(argv[1]);
+            }
+            if (argv.length > 2) {
+                throw new Error(`Unexpected argument: ${argv[2]}`);
+            }
+        }
+        else if (argv.length > 1) {
             throw new Error(`Unexpected argument: ${argv[1]}`);
         }
     }
     async run() {
-        if (this._name) {
+        if (this._topic) {
+            (0,print/* printShowTopicUsage */.v9)(this._topic);
+        }
+        else if (this._name) {
             (0,print/* printCommandUsage */.CZ)(this._name);
         }
         else {
@@ -42530,6 +42480,7 @@ class Help {
 }
 
 ;// CONCATENATED MODULE: ./src/command.ts
+
 
 
 
@@ -42550,6 +42501,7 @@ var CommandName;
     CommandName["CurrentPlatform"] = "current-platform";
     CommandName["Preset"] = "preset";
     CommandName["Ci"] = "ci";
+    CommandName["Show"] = "show";
 })(CommandName || (CommandName = {}));
 ;
 function isCommandName(s) {
@@ -42571,7 +42523,8 @@ const COMMANDS = {
     [CommandName.ListPlatforms]: ListPlatforms,
     [CommandName.CurrentPlatform]: CurrentPlatform,
     [CommandName.Preset]: Preset,
-    [CommandName.Ci]: Ci
+    [CommandName.Ci]: Ci,
+    [CommandName.Show]: show/* default */.ZP
 };
 function commandFor(name) {
     return COMMANDS[name];
@@ -42583,11 +42536,307 @@ function summaries() {
         { name: CommandName.Bump, summary: Bump.summary() },
         { name: CommandName.AddPlatform, summary: AddPlatform.summary() },
         { name: CommandName.UpdatePlatforms, summary: UpdatePlatforms.summary() },
-        { name: CommandName.ListPlatforms, summary: ListPlatforms.summary() },
-        { name: CommandName.CurrentPlatform, summary: CurrentPlatform.summary() },
-        { name: CommandName.Preset, summary: Preset.summary() },
-        { name: CommandName.Ci, summary: Ci.summary() }
+        { name: CommandName.Show, summary: show/* default.summary */.ZP.summary() }
     ];
+}
+
+
+/***/ }),
+
+/***/ 6264:
+/***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
+
+
+// EXPORTS
+__nccwpck_require__.d(__webpack_exports__, {
+  "sY": () => (/* binding */ asTopic),
+  "ZP": () => (/* binding */ Show),
+  "D8": () => (/* binding */ subcommandFor)
+});
+
+// UNUSED EXPORTS: Topic
+
+// EXTERNAL MODULE: ../node_modules/command-line-args/dist/index.js
+var dist = __nccwpck_require__(7898);
+var dist_default = /*#__PURE__*/__nccwpck_require__.n(dist);
+// EXTERNAL MODULE: ../node_modules/@neon-rs/manifest/lib/index.mjs
+var lib = __nccwpck_require__(347);
+;// CONCATENATED MODULE: ./src/commands/show/platforms.ts
+
+
+const OPTIONS = [
+    { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
+];
+class Platforms {
+    static summary() { return 'Display information about this project\'s supported platforms.'; }
+    static syntax() { return 'neon show platforms [-v]'; }
+    static options() {
+        return [
+            { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' }
+        ];
+    }
+    static seeAlso() { }
+    static extraSection() { }
+    _verbose;
+    constructor(argv) {
+        const options = dist_default()(OPTIONS, { argv, partial: true });
+        this._verbose = !!options.verbose;
+    }
+    log(msg) {
+        if (this._verbose) {
+            console.error("[neon show platforms] " + msg);
+        }
+    }
+    async run() {
+        this.log(`reading package.json`);
+        const libManifest = await lib/* LibraryManifest.load */.N.load();
+        this.log(`manifest: ${libManifest.stringify()}`);
+        const platforms = libManifest.allPlatforms();
+        console.log(JSON.stringify(platforms, null, 2));
+    }
+}
+
+// EXTERNAL MODULE: ./src/provider.ts + 2 modules
+var provider = __nccwpck_require__(545);
+;// CONCATENATED MODULE: ./src/commands/show/ci.ts
+
+
+
+const ci_OPTIONS = [
+    { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
+];
+class CI {
+    static summary() { return 'Display CI metadata for this project\'s platforms.'; }
+    static syntax() { return 'neon show ci [-v] <provider>'; }
+    static options() {
+        return [
+            { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' },
+            { name: '<provider>', summary: 'CI provider, which can be one of the supported providers listed below.' }
+        ];
+    }
+    static seeAlso() {
+        return [
+            { name: 'GitHub Actions', summary: '<https://docs.github.com/actions>' }
+        ];
+    }
+    static extraSection() {
+        return {
+            title: 'CI Providers',
+            details: [
+                { name: 'github', summary: 'GitHub Actions.' }
+            ]
+        };
+    }
+    _verbose;
+    _provider;
+    constructor(argv) {
+        const options = dist_default()(ci_OPTIONS, { argv, partial: true });
+        this._verbose = !!options.verbose;
+        if (!options._unknown || options._unknown.length === 0) {
+            throw new Error("No arguments found, expected <provider>.");
+        }
+        const providerName = (0,provider/* asProviderName */.tb)(options._unknown[0]);
+        const providerCtor = (0,provider/* providerFor */.kq)(providerName);
+        this._provider = new providerCtor();
+    }
+    log(msg) {
+        if (this._verbose) {
+            console.error("[neon show ci] " + msg);
+        }
+    }
+    async run() {
+        this.log(`reading package.json`);
+        const libManifest = await lib/* LibraryManifest.load */.N.load();
+        this.log(`manifest: ${libManifest.stringify()}`);
+        const platforms = libManifest.allPlatforms();
+        const metadata = this._provider.metadata(platforms);
+        console.log(JSON.stringify(metadata, null, 2));
+    }
+}
+
+// EXTERNAL MODULE: ../node_modules/@neon-rs/manifest/lib/platform.mjs
+var platform = __nccwpck_require__(8140);
+;// CONCATENATED MODULE: ./src/commands/show/preset.ts
+
+
+const preset_OPTIONS = [
+    { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
+];
+class Preset {
+    static summary() { return 'Display target information about a platform preset.'; }
+    static syntax() { return 'neon show preset [-v] <preset>'; }
+    static options() {
+        return [
+            { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' },
+            { name: '<preset>', summary: 'The target family preset to look up.' },
+        ];
+    }
+    static seeAlso() { }
+    static extraSection() { }
+    _json;
+    _verbose;
+    _preset;
+    constructor(argv) {
+        const options = dist_default()(preset_OPTIONS, { argv, partial: true });
+        this._json = options.json || false;
+        this._verbose = !!options.verbose;
+        if (!options._unknown || options._unknown.length === 0) {
+            throw new Error("Missing argument, expected <preset>");
+        }
+        if (options._unknown.length > 1) {
+            throw new Error(`Unexpected argument ${options._unknown[1]}`);
+        }
+        (0,platform/* assertIsPlatformPreset */.Zv)(options._unknown[0]);
+        this._preset = options._unknown[0];
+    }
+    log(msg) {
+        if (this._verbose) {
+            console.error("[neon show preset] " + msg);
+        }
+    }
+    async run() {
+        const map = (0,platform/* expandPlatformPreset */.EY)(this._preset);
+        console.log(JSON.stringify(map, null, 2));
+    }
+}
+
+// EXTERNAL MODULE: ./node_modules/@neon-rs/load/dist/index.js
+var load_dist = __nccwpck_require__(8938);
+;// CONCATENATED MODULE: ./src/commands/show/system.ts
+
+
+const system_OPTIONS = [
+    { name: 'json', type: Boolean, defaultValue: false },
+    { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
+];
+class System {
+    static summary() { return 'Display information about the current system.'; }
+    static syntax() { return 'neon show system [--json] [-v]'; }
+    static options() {
+        return [
+            { name: '--json', summary: 'Display platform info in JSON format. (Default: false)' },
+            { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' }
+        ];
+    }
+    static seeAlso() { }
+    static extraSection() { }
+    _json;
+    _verbose;
+    constructor(argv) {
+        const options = dist_default()(system_OPTIONS, { argv, partial: true });
+        this._json = options.json || false;
+        this._verbose = !!options.verbose;
+    }
+    log(msg) {
+        if (this._verbose) {
+            console.error("[neon show system] " + msg);
+        }
+    }
+    async run() {
+        if (this._json) {
+            const [os, arch, abi] = (0,load_dist/* currentPlatform */.ob)().split('-');
+            const json = {
+                os,
+                arch,
+                abi: abi || null
+            };
+            console.log(JSON.stringify(json, null, 2));
+        }
+        else {
+            console.log((0,load_dist/* currentPlatform */.ob)());
+        }
+    }
+}
+
+;// CONCATENATED MODULE: ./src/commands/show.ts
+
+
+
+
+
+const show_OPTIONS = [
+    { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
+];
+var Topic;
+(function (Topic) {
+    Topic["PLATFORMS"] = "platforms";
+    Topic["SYSTEM"] = "system";
+    Topic["PRESET"] = "preset";
+    Topic["CI"] = "ci";
+})(Topic || (Topic = {}));
+function subcommandFor(topic) {
+    switch (topic) {
+        case Topic.CI:
+            return CI;
+        case Topic.PLATFORMS:
+            return Platforms;
+        case Topic.PRESET:
+            return Preset;
+        case Topic.SYSTEM:
+            return System;
+    }
+}
+function isTopic(x) {
+    return ['platforms', 'system', 'preset', 'ci'].includes(x);
+}
+function asTopic(x) {
+    if (!isTopic(x)) {
+        throw new RangeError(`expected <topic>, got ${x}`);
+    }
+    return x;
+}
+function assertIsTopic(x) {
+    if (!isTopic(x)) {
+        throw new RangeError(`expected <topic>, got ${x}`);
+    }
+}
+class Show {
+    static summary() { return 'Display information about the project or current system.'; }
+    static syntax() { return 'neon show <topic>'; }
+    static options() {
+        return [
+            { name: '<topic>', summary: 'The topic to display information about.' },
+            { name: '', summary: 'Run `neon help show <topic>` for details about a topic.' }
+        ];
+    }
+    static seeAlso() { }
+    static extraSection() {
+        return {
+            title: 'Topics',
+            details: [
+                { name: 'ci', summary: 'CI metadata for this project\'s platforms.' },
+                { name: 'platforms', summary: 'Information about this project\'s supported platforms.' },
+                { name: 'preset', summary: 'Target information about a platform preset.' },
+                { name: 'system', summary: 'Information about the current system.' }
+            ]
+        };
+    }
+    _topic;
+    _argv;
+    constructor(argv) {
+        const options = dist_default()(show_OPTIONS, { argv, stopAtFirstUnknown: true, partial: true });
+        if (!options._unknown || options._unknown.length === 0) {
+            throw new Error("Missing argument, expected <topic>");
+        }
+        assertIsTopic(options._unknown[0]);
+        this._topic = options._unknown[0];
+        this._argv = options._unknown.slice(1);
+    }
+    subcommand() {
+        switch (this._topic) {
+            case Topic.PLATFORMS:
+                return new Platforms(this._argv);
+            case Topic.CI:
+                return new CI(this._argv);
+            case Topic.PRESET:
+                return new Preset(this._argv);
+            case Topic.SYSTEM:
+                return new System(this._argv);
+        }
+    }
+    async run() {
+        await this.subcommand().run();
+    }
 }
 
 
@@ -42600,7 +42849,7 @@ __nccwpck_require__.a(module, async (__webpack_handle_async_dependencies__, __we
 /* harmony import */ var command_line_commands__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(5046);
 /* harmony import */ var command_line_commands__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(command_line_commands__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var _print_js__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(9050);
-/* harmony import */ var _command_js__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(3149);
+/* harmony import */ var _command_js__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(7931);
 /* harmony import */ var node_module__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(2033);
 /* harmony import */ var node_module__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__nccwpck_require__.n(node_module__WEBPACK_IMPORTED_MODULE_3__);
 
@@ -42661,7 +42910,8 @@ __nccwpck_require__.d(__webpack_exports__, {
   "CZ": () => (/* binding */ printCommandUsage),
   "OS": () => (/* binding */ printError),
   "Yv": () => (/* binding */ printErrorWithUsage),
-  "yY": () => (/* binding */ printMainUsage)
+  "yY": () => (/* binding */ printMainUsage),
+  "v9": () => (/* binding */ printShowTopicUsage)
 });
 
 ;// CONCATENATED MODULE: ../node_modules/command-line-usage/node_modules/array-back/index.js
@@ -45628,9 +45878,12 @@ const chalkStderr = createChalk({level: stderrColor ? stderrColor.level : 0});
 
 /* harmony default export */ const chalk_source = (chalk);
 
-// EXTERNAL MODULE: ./src/command.ts + 40 modules
-var command = __nccwpck_require__(3149);
+// EXTERNAL MODULE: ./src/command.ts + 35 modules
+var command = __nccwpck_require__(7931);
+// EXTERNAL MODULE: ./src/commands/show.ts + 4 modules
+var show = __nccwpck_require__(6264);
 ;// CONCATENATED MODULE: ./src/print.ts
+
 
 
 
@@ -45691,6 +45944,9 @@ function mainUsage() {
     ];
     return command_line_usage(sections).trim();
 }
+function printShowTopicUsage(topic) {
+    console.error(commandUsage(topic, (0,show/* subcommandFor */.D8)(topic)));
+}
 function printCommandUsage(name) {
     console.error(commandUsage(name, (0,command/* commandFor */.Nl)(name)));
 }
@@ -45706,6 +45962,83 @@ function printErrorWithUsage(e) {
 }
 function printError(e) {
     console.error(chalk_source.bold.red("error:") + " " + ((e instanceof Error) ? e.message : String(e)));
+}
+
+
+/***/ }),
+
+/***/ 545:
+/***/ ((__unused_webpack_module, __webpack_exports__, __nccwpck_require__) => {
+
+
+// EXPORTS
+__nccwpck_require__.d(__webpack_exports__, {
+  "tb": () => (/* binding */ asProviderName),
+  "kq": () => (/* binding */ providerFor)
+});
+
+// UNUSED EXPORTS: ProviderName, isProviderName
+
+;// CONCATENATED MODULE: ./data/github.json
+const github_namespaceObject = JSON.parse('{"darwin-arm64":"macOS","darwin-x64":"macOS","ios-arm64":null,"ios-x64":null,"android-arm64":"Linux","android-arm-eabi":"Linux","android-ia32":null,"android-x64":"Linux","win32-arm64-msvc":"Windows","win32-ia32-gnu":null,"win32-ia32-msvc":null,"win32-x64-gnu":null,"win32-x64-msvc":"Windows","linux-arm64-gnu":"Linux","linux-arm64-musl":null,"linux-arm-gnueabihf":"Linux","linux-arm-musleabihf":null,"linux-ia32-gnu":null,"linux-ia32-musl":null,"linux-mips-gnu":null,"linux-mips-musl":null,"linux-mips64-gnuabi64":null,"linux-mips64-muslabi64":null,"linux-mips64el-gnuabi64":null,"linux-mips64el-muslabi64":null,"linux-mipsel-gnu":null,"linux-mipsel-musl":null,"linux-powerpc-gnu":null,"linux-powerpc64-gnu":null,"linux-powerpc64le-gnu":null,"linux-riscv64gc-gnu":null,"linux-s390x-gnu":null,"linux-sparc64-gnu":null,"linux-x64-gnu":"Linux","linux-x64-gnux32":null,"linux-x64-musl":null,"freebsd-ia32":null,"freebsd-x64":null}');
+;// CONCATENATED MODULE: ./src/ci/github.ts
+
+function sort(platforms) {
+    const macOS = new Set();
+    const Windows = new Set();
+    const Linux = new Set();
+    const unsupported = new Set();
+    for (const platform of platforms) {
+        switch (github_namespaceObject[platform]) {
+            case 'macOS':
+                macOS.add(platform);
+                break;
+            case 'Windows':
+                Windows.add(platform);
+                break;
+            case 'Linux':
+                Linux.add(platform);
+                break;
+            default:
+                unsupported.add(platform);
+                break;
+        }
+    }
+    return {
+        macOS: [...macOS],
+        Windows: [...Windows],
+        Linux: [...Linux],
+        unsupported: [...unsupported]
+    };
+}
+class GitHub {
+    metadata(platforms) {
+        return sort(Object.keys(platforms));
+    }
+}
+
+;// CONCATENATED MODULE: ./src/provider.ts
+
+var ProviderName;
+(function (ProviderName) {
+    ProviderName["GitHub"] = "github";
+})(ProviderName || (ProviderName = {}));
+;
+const PROVIDERS = {
+    [ProviderName.GitHub]: GitHub
+};
+function isProviderName(s) {
+    const keys = Object.values(ProviderName);
+    return keys.includes(s);
+}
+function asProviderName(name) {
+    if (!isProviderName(name)) {
+        throw new RangeError(`CI provider not recognized: ${name}`);
+    }
+    return name;
+}
+function providerFor(name) {
+    return PROVIDERS[name];
 }
 
 
@@ -61531,6 +61864,36 @@ class AbstractManifest {
     }
 }
 exports.AbstractManifest = AbstractManifest;
+
+
+/***/ }),
+
+/***/ 347:
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __nccwpck_require__) => {
+
+/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
+/* harmony export */   "N": () => (/* reexport safe */ _index_cjs__WEBPACK_IMPORTED_MODULE_0__.N)
+/* harmony export */ });
+/* harmony import */ var _index_cjs__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(4696);
+
+
+
+/***/ }),
+
+/***/ 8140:
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __nccwpck_require__) => {
+
+/* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
+/* harmony export */   "EY": () => (/* reexport safe */ _platform_cjs__WEBPACK_IMPORTED_MODULE_0__.expandPlatformPreset),
+/* harmony export */   "FZ": () => (/* reexport safe */ _platform_cjs__WEBPACK_IMPORTED_MODULE_0__.isRustTarget),
+/* harmony export */   "Qm": () => (/* reexport safe */ _platform_cjs__WEBPACK_IMPORTED_MODULE_0__.isPlatformPreset),
+/* harmony export */   "Zv": () => (/* reexport safe */ _platform_cjs__WEBPACK_IMPORTED_MODULE_0__.assertIsPlatformPreset),
+/* harmony export */   "bC": () => (/* reexport safe */ _platform_cjs__WEBPACK_IMPORTED_MODULE_0__.isNodePlatform),
+/* harmony export */   "or": () => (/* reexport safe */ _platform_cjs__WEBPACK_IMPORTED_MODULE_0__.assertIsNodePlatform),
+/* harmony export */   "sD": () => (/* reexport safe */ _platform_cjs__WEBPACK_IMPORTED_MODULE_0__.assertIsRustTarget)
+/* harmony export */ });
+/* harmony import */ var _platform_cjs__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(2147);
+
 
 
 /***/ }),

--- a/dist/cli/package.json
+++ b/dist/cli/package.json
@@ -27,12 +27,12 @@
   },
   "homepage": "https://github.com/dherman/neon-rs#readme",
   "optionalDependencies": {
-    "@cargo-messages/android-arm-eabi": "0.1.65",
-    "@cargo-messages/darwin-arm64": "0.1.65",
-    "@cargo-messages/darwin-x64": "0.1.65",
-    "@cargo-messages/linux-arm-gnueabihf": "0.1.65",
-    "@cargo-messages/linux-x64-gnu": "0.1.65",
-    "@cargo-messages/win32-arm64-msvc": "0.1.65",
-    "@cargo-messages/win32-x64-msvc": "0.1.65"
+    "@cargo-messages/android-arm-eabi": "0.1.66",
+    "@cargo-messages/darwin-arm64": "0.1.66",
+    "@cargo-messages/darwin-x64": "0.1.66",
+    "@cargo-messages/linux-arm-gnueabihf": "0.1.66",
+    "@cargo-messages/linux-x64-gnu": "0.1.66",
+    "@cargo-messages/win32-arm64-msvc": "0.1.66",
+    "@cargo-messages/win32-x64-msvc": "0.1.66"
   }
 }

--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@neon-rs/load": "^0.0.181",
     "@neon-rs/manifest": "^0.0.5",
-    "cargo-messages": "^0.1.65",
+    "cargo-messages": "^0.1.66",
     "chalk": "^5.2.0",
     "command-line-args": "^5.2.1",
     "command-line-commands": "^3.0.2",
@@ -65,12 +65,12 @@
     "temp": "^0.9.4"
   },
   "optionalDependencies": {
-    "@cargo-messages/android-arm-eabi": "0.1.65",
-    "@cargo-messages/darwin-arm64": "0.1.65",
-    "@cargo-messages/darwin-x64": "0.1.65",
-    "@cargo-messages/linux-arm-gnueabihf": "0.1.65",
-    "@cargo-messages/linux-x64-gnu": "0.1.65",
-    "@cargo-messages/win32-arm64-msvc": "0.1.65",
-    "@cargo-messages/win32-x64-msvc": "0.1.65"
+    "@cargo-messages/android-arm-eabi": "0.1.66",
+    "@cargo-messages/darwin-arm64": "0.1.66",
+    "@cargo-messages/darwin-x64": "0.1.66",
+    "@cargo-messages/linux-arm-gnueabihf": "0.1.66",
+    "@cargo-messages/linux-x64-gnu": "0.1.66",
+    "@cargo-messages/win32-arm64-msvc": "0.1.66",
+    "@cargo-messages/win32-x64-msvc": "0.1.66"
   }
 }

--- a/src/cli/src/command.ts
+++ b/src/cli/src/command.ts
@@ -7,6 +7,7 @@ import CurrentPlatform from './commands/current-platform.js';
 import Preset from './commands/preset.js';
 import Ci from './commands/ci.js';
 import Help from './commands/help.js';
+import Show from './commands/show.js';
 
 export interface Command {
   run(): Promise<void>;
@@ -35,10 +36,11 @@ export enum CommandName {
   Bump = 'bump',
   AddPlatform = 'add-platform',
   UpdatePlatforms = 'update-platforms',
-  ListPlatforms = 'list-platforms',
-  CurrentPlatform = 'current-platform',
-  Preset = 'preset',
-  Ci = 'ci'
+  ListPlatforms = 'list-platforms', // DEPRECATED(0.2)
+  CurrentPlatform = 'current-platform', // DEPRECATED(0.2)
+  Preset = 'preset', // DEPRECATED(0.2)
+  Ci = 'ci', // DEPRECATED(0.2)
+  Show = 'show'
 };
 
 export function isCommandName(s: string): s is CommandName {
@@ -62,7 +64,8 @@ const COMMANDS: Record<CommandName, CommandClass> = {
   [CommandName.ListPlatforms]: ListPlatforms,
   [CommandName.CurrentPlatform]: CurrentPlatform,
   [CommandName.Preset]: Preset,
-  [CommandName.Ci]: Ci
+  [CommandName.Ci]: Ci,
+  [CommandName.Show]: Show
 };
 
 export function commandFor(name: CommandName): CommandClass {
@@ -76,9 +79,6 @@ export function summaries(): CommandDetail[] {
     { name: CommandName.Bump, summary: Bump.summary() },
     { name: CommandName.AddPlatform, summary: AddPlatform.summary() },
     { name: CommandName.UpdatePlatforms, summary: UpdatePlatforms.summary() },
-    { name: CommandName.ListPlatforms, summary: ListPlatforms.summary() },
-    { name: CommandName.CurrentPlatform, summary: CurrentPlatform.summary() },
-    { name: CommandName.Preset, summary: Preset.summary() },
-    { name: CommandName.Ci, summary: Ci.summary() }
+    { name: CommandName.Show, summary: Show.summary() }
   ];
 }

--- a/src/cli/src/command.ts
+++ b/src/cli/src/command.ts
@@ -1,7 +1,7 @@
 import Dist from './commands/dist.js';
 import Bump from './commands/bump.js';
-import AddPlatform from './commands/add-platform.js';
-import UpdatePlatforms from './commands/update-platforms.js';
+import Add from './commands/add.js';
+import Update from './commands/update.js';
 import ListPlatforms from './commands/list-platforms.js';
 import CurrentPlatform from './commands/current-platform.js';
 import Preset from './commands/preset.js';
@@ -34,8 +34,10 @@ export enum CommandName {
   Help = 'help',
   Dist = 'dist',
   Bump = 'bump',
-  AddPlatform = 'add-platform',
-  UpdatePlatforms = 'update-platforms',
+  Add = 'add',
+  Update = 'update',
+  AddPlatform = 'add-platform', // DEPRECATED(0.2)
+  UpdatePlatforms = 'update-platforms', // DEPRECATED(0.2)
   ListPlatforms = 'list-platforms', // DEPRECATED(0.2)
   CurrentPlatform = 'current-platform', // DEPRECATED(0.2)
   Preset = 'preset', // DEPRECATED(0.2)
@@ -59,8 +61,10 @@ const COMMANDS: Record<CommandName, CommandClass> = {
   [CommandName.Help]: Help,
   [CommandName.Dist]: Dist,
   [CommandName.Bump]: Bump,
-  [CommandName.AddPlatform]: AddPlatform,
-  [CommandName.UpdatePlatforms]: UpdatePlatforms,
+  [CommandName.Add]: Add,
+  [CommandName.Update]: Update,
+  [CommandName.AddPlatform]: Add,
+  [CommandName.UpdatePlatforms]: Update,
   [CommandName.ListPlatforms]: ListPlatforms,
   [CommandName.CurrentPlatform]: CurrentPlatform,
   [CommandName.Preset]: Preset,
@@ -77,8 +81,8 @@ export function summaries(): CommandDetail[] {
     { name: CommandName.Help, summary: Help.summary() },
     { name: CommandName.Dist, summary: Dist.summary() },
     { name: CommandName.Bump, summary: Bump.summary() },
-    { name: CommandName.AddPlatform, summary: AddPlatform.summary() },
-    { name: CommandName.UpdatePlatforms, summary: UpdatePlatforms.summary() },
+    { name: CommandName.Add, summary: Add.summary() },
+    { name: CommandName.Update, summary: Update.summary() },
     { name: CommandName.Show, summary: Show.summary() }
   ];
 }

--- a/src/cli/src/commands/add.ts
+++ b/src/cli/src/commands/add.ts
@@ -18,9 +18,9 @@ const OPTIONS = [
   { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
 ];
 
-export default class AddPlatform implements Command {
+export default class Add implements Command {
     static summary(): string { return 'Add a platform or platform preset to a Neon project.'; }
-    static syntax(): string { return 'neon add-platform [<p> | --os <a> --arch <b> [--abi <c>]] [-o <d>] [-b <f>]'; }
+    static syntax(): string { return 'neon add [<p> | --os <a> --arch <b> [--abi <c>]] [-o <d>] [-b <f>]'; }
     static options(): CommandDetail[] {
       return [
         { name: '<p>', summary: 'A Node platform or platform preset.' },
@@ -95,7 +95,7 @@ export default class AddPlatform implements Command {
 
     log(msg: string) {
       if (this._verbose) {
-        console.error("[neon add-platform] " + msg);
+        console.error("[neon add] " + msg);
       }
     }
   

--- a/src/cli/src/commands/help.ts
+++ b/src/cli/src/commands/help.ts
@@ -1,5 +1,6 @@
-import { printMainUsage, printCommandUsage } from '../print.js';
+import { printMainUsage, printCommandUsage, printShowTopicUsage } from '../print.js';
 import { Command, CommandName, CommandDetail, CommandSection, asCommandName } from '../command.js';
+import { Topic, asTopic } from './show.js';
 
 export default class Help implements Command {
   static summary(): string { return 'Display help information about Neon.'; }
@@ -13,16 +14,28 @@ export default class Help implements Command {
   static extraSection(): CommandSection | void { }
 
   private _name?: CommandName;
+  private _topic?: Topic;
 
   constructor(argv: string[]) {
     this._name = argv.length > 0 ? asCommandName(argv[0]) : undefined;
-    if (argv.length > 1) {
+    this._topic = undefined;
+
+    if (this._name === CommandName.Show) {
+      if (argv.length === 2) {
+        this._topic = asTopic(argv[1]);
+      }
+      if (argv.length > 2) {
+        throw new Error(`Unexpected argument: ${argv[2]}`);
+      }
+    } else if (argv.length > 1) {
       throw new Error(`Unexpected argument: ${argv[1]}`);
     }
   }
 
   async run() {
-    if (this._name) {
+    if (this._topic) {
+      printShowTopicUsage(this._topic);
+    } else if (this._name) {
       printCommandUsage(this._name);
     } else {
       printMainUsage();

--- a/src/cli/src/commands/show.ts
+++ b/src/cli/src/commands/show.ts
@@ -1,0 +1,105 @@
+import commandLineArgs from 'command-line-args';
+import { Command, CommandClass, CommandDetail, CommandSection } from '../command.js';
+import { LibraryManifest } from '@neon-rs/manifest';
+import { currentPlatform } from '@neon-rs/load';
+import { NodePlatform, PlatformMap } from '@neon-rs/manifest/platform';
+import Platforms from './show/platforms.js';
+import CI from './show/ci.js';
+import Preset from './show/preset.js';
+import System from './show/system.js';
+
+const OPTIONS = [
+  { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
+];
+
+export enum Topic {
+  PLATFORMS = 'platforms',
+  SYSTEM = 'system',
+  PRESET = 'preset',
+  CI = 'ci'
+}
+
+export function subcommandFor(topic: Topic): CommandClass {
+  switch (topic) {
+    case Topic.CI:
+      return CI;
+    case Topic.PLATFORMS:
+      return Platforms;
+    case Topic.PRESET:
+      return Preset;
+    case Topic.SYSTEM:
+      return System;
+  }
+}
+
+function isTopic(x: string): x is Topic {
+  return ['platforms', 'system', 'preset', 'ci'].includes(x);
+}
+
+export function asTopic(x: string): Topic {
+  if (!isTopic(x)) {
+    throw new RangeError(`expected <topic>, got ${x}`);
+  }
+  return x;
+}
+
+function assertIsTopic(x: string): asserts x is Topic {
+  if (!isTopic(x)) {
+    throw new RangeError(`expected <topic>, got ${x}`);
+  }
+}
+
+export default class Show implements Command {
+  static summary(): string { return 'Display information about the project or current system.'; }
+  static syntax(): string { return 'neon show <topic>'; }
+  static options(): CommandDetail[] {
+    return [
+      { name: '<topic>', summary: 'The topic to display information about.' },
+      { name: '', summary: 'Run `neon help show <topic>` for details about a topic.' }
+    ];
+  }
+  static seeAlso(): CommandDetail[] | void { }
+  static extraSection(): CommandSection | void {
+    return {
+      title: 'Topics',
+      details: [
+        { name: 'ci', summary: 'CI metadata for this project\'s platforms.' },
+        { name: 'platforms', summary: 'Information about this project\'s supported platforms.' },
+        { name: 'preset', summary: 'Target information about a platform preset.' },
+        { name: 'system', summary: 'Information about the current system.' }
+      ]
+    };
+  }
+  
+  private _topic: Topic;
+  private _argv: string[];
+
+  constructor(argv: string[]) {
+    const options = commandLineArgs(OPTIONS, { argv, stopAtFirstUnknown: true, partial: true });
+  
+    if (!options._unknown || options._unknown.length === 0) {
+      throw new Error("Missing argument, expected <topic>");
+    }
+
+    assertIsTopic(options._unknown[0]);
+    this._topic = options._unknown[0];
+    this._argv = options._unknown.slice(1);
+  }
+
+  subcommand(): Command {
+    switch (this._topic) {
+      case Topic.PLATFORMS:
+        return new Platforms(this._argv);
+      case Topic.CI:
+        return new CI(this._argv);
+      case Topic.PRESET:
+        return new Preset(this._argv);
+      case Topic.SYSTEM:
+        return new System(this._argv);
+    }
+  }
+
+  async run() {
+    await this.subcommand().run();
+  }
+}

--- a/src/cli/src/commands/show/ci.ts
+++ b/src/cli/src/commands/show/ci.ts
@@ -1,0 +1,62 @@
+import commandLineArgs from 'command-line-args';
+import { Command, CommandDetail, CommandSection } from '../../command.js';
+import { LibraryManifest } from '@neon-rs/manifest';
+import { asProviderName, providerFor, Provider } from '../../provider.js';
+
+const OPTIONS = [
+  { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
+];
+
+export default class CI implements Command {
+  static summary(): string { return 'Display CI metadata for this project\'s platforms.'; }
+  static syntax(): string { return 'neon show ci [-v] <provider>'; }
+  static options(): CommandDetail[] {
+    return [
+      { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' },
+      { name: '<provider>', summary: 'CI provider, which can be one of the supported providers listed below.'}
+    ];
+  }
+  static seeAlso(): CommandDetail[] | void {
+    return [
+      { name: 'GitHub Actions', summary: '<https://docs.github.com/actions>' }
+    ];
+  }
+  static extraSection(): CommandSection | void {
+    return {
+      title: 'CI Providers',
+      details: [
+        { name: 'github', summary: 'GitHub Actions.' }
+      ]
+    };
+  }
+
+  private _verbose: boolean;
+  private _provider: Provider;
+
+  constructor(argv: string[]) {
+    const options = commandLineArgs(OPTIONS, { argv, partial: true });
+
+    this._verbose = !!options.verbose;
+    if (!options._unknown || options._unknown.length === 0) {
+      throw new Error("No arguments found, expected <provider>.");
+    }
+    const providerName = asProviderName(options._unknown[0]);
+    const providerCtor = providerFor(providerName);
+    this._provider = new providerCtor();
+  }
+
+  log(msg: string) {
+    if (this._verbose) {
+      console.error("[neon show ci] " + msg);
+    }
+  }
+
+  async run() {
+    this.log(`reading package.json`);
+    const libManifest = await LibraryManifest.load();
+    this.log(`manifest: ${libManifest.stringify()}`);
+    const platforms = libManifest.allPlatforms();
+    const metadata = this._provider.metadata(platforms);
+    console.log(JSON.stringify(metadata, null, 2));
+  }
+}

--- a/src/cli/src/commands/show/platforms.ts
+++ b/src/cli/src/commands/show/platforms.ts
@@ -1,0 +1,41 @@
+import commandLineArgs from 'command-line-args';
+import { Command, CommandDetail, CommandSection } from '../../command.js';
+import { LibraryManifest } from '@neon-rs/manifest';
+
+const OPTIONS = [
+  { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
+];
+
+export default class Platforms implements Command {
+  static summary(): string { return 'Display information about this project\'s supported platforms.'; }
+  static syntax(): string { return 'neon show platforms [-v]'; }
+  static options(): CommandDetail[] {
+    return [
+      { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' }
+    ];
+  }
+  static seeAlso(): CommandDetail[] | void { }
+  static extraSection(): CommandSection | void { }
+  
+  private _verbose: boolean;
+
+  constructor(argv: string[]) {
+    const options = commandLineArgs(OPTIONS, { argv, partial: true });
+  
+    this._verbose = !!options.verbose;
+  }
+
+  log(msg: string) {
+    if (this._verbose) {
+      console.error("[neon show platforms] " + msg);
+    }
+  }
+
+  async run() {
+    this.log(`reading package.json`);
+    const libManifest = await LibraryManifest.load();
+    this.log(`manifest: ${libManifest.stringify()}`);
+    const platforms = libManifest.allPlatforms();
+    console.log(JSON.stringify(platforms, null, 2));
+  }
+}

--- a/src/cli/src/commands/show/preset.ts
+++ b/src/cli/src/commands/show/preset.ts
@@ -1,0 +1,53 @@
+import commandLineArgs from 'command-line-args';
+import { Command, CommandDetail, CommandSection } from '../../command.js';
+import { assertIsPlatformPreset, expandPlatformPreset, PlatformPreset, NodePlatform, PlatformMap } from '@neon-rs/manifest/platform';
+
+const OPTIONS = [
+  { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
+];
+
+export default class Preset implements Command {
+  static summary(): string { return 'Display target information about a platform preset.'; }
+  static syntax(): string { return 'neon show preset [-v] <preset>'; }
+  static options(): CommandDetail[] {
+    return [
+      { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' },
+      { name: '<preset>', summary: 'The target family preset to look up.' },
+    ];
+  }
+  static seeAlso(): CommandDetail[] | void { }
+  static extraSection(): CommandSection | void { }
+  
+  private _json: boolean;
+  private _verbose: boolean;
+  private _preset: PlatformPreset;
+
+  constructor(argv: string[]) {
+    const options = commandLineArgs(OPTIONS, { argv, partial: true });
+  
+    this._json = options.json || false;
+    this._verbose = !!options.verbose;
+
+    if (!options._unknown || options._unknown.length === 0) {
+      throw new Error("Missing argument, expected <preset>");
+    }
+
+    if (options._unknown.length > 1) {
+      throw new Error(`Unexpected argument ${options._unknown[1]}`);
+    }
+
+    assertIsPlatformPreset(options._unknown[0]);
+    this._preset = options._unknown[0];
+  }
+
+  log(msg: string) {
+    if (this._verbose) {
+      console.error("[neon show preset] " + msg);
+    }
+  }
+
+  async run() {
+    const map = expandPlatformPreset(this._preset);
+    console.log(JSON.stringify(map, null, 2));
+  }
+}

--- a/src/cli/src/commands/show/system.ts
+++ b/src/cli/src/commands/show/system.ts
@@ -1,0 +1,51 @@
+import commandLineArgs from 'command-line-args';
+import { Command, CommandDetail, CommandSection } from '../../command.js';
+import { currentPlatform } from '@neon-rs/load';
+
+const OPTIONS = [
+  { name: 'json', type: Boolean, defaultValue: false },
+  { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
+];
+
+export default class System implements Command {
+  static summary(): string { return 'Display information about the current system.'; }
+  static syntax(): string { return 'neon show system [--json] [-v]'; }
+  static options(): CommandDetail[] {
+    return [
+      { name: '--json', summary: 'Display platform info in JSON format. (Default: false)' },
+      { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' }
+    ];
+  }
+  static seeAlso(): CommandDetail[] | void { }
+  static extraSection(): CommandSection | void { }
+  
+  private _json: boolean;
+  private _verbose: boolean;
+
+  constructor(argv: string[]) {
+    const options = commandLineArgs(OPTIONS, { argv, partial: true });
+  
+    this._json = options.json || false;
+    this._verbose = !!options.verbose;
+  }
+
+  log(msg: string) {
+    if (this._verbose) {
+      console.error("[neon show system] " + msg);
+    }
+  }
+
+  async run() {
+    if (this._json) {
+      const [os, arch, abi] = currentPlatform().split('-');
+      const json = {
+        os,
+        arch,
+        abi: abi || null
+      };
+      console.log(JSON.stringify(json, null, 2));
+    } else {
+      console.log(currentPlatform());
+    }
+  }
+}

--- a/src/cli/src/commands/update.ts
+++ b/src/cli/src/commands/update.ts
@@ -6,19 +6,15 @@ const OPTIONS = [
   { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
 ];
 
-export default class UpdatePlatforms implements Command {
+export default class Update implements Command {
   static summary(): string { return 'Update configuration for all build platforms in package.json.'; }
-  static syntax(): string { return 'neon update-platforms [-b <file>]'; }
+  static syntax(): string { return 'neon update [-v]'; }
   static options(): CommandDetail[] {
     return [
       { name: '-v, --verbose', summary: 'Enable verbose logging. (Default: false)' }
     ];
   }
-  static seeAlso(): CommandDetail[] | void {
-    return [
-      { name: 'ncc', summary: '<https://github.com/vercel/ncc>' }
-    ];
-  }
+  static seeAlso(): CommandDetail[] | void { }
   static extraSection(): CommandSection | void { }
 
   private _verbose: boolean;
@@ -31,7 +27,7 @@ export default class UpdatePlatforms implements Command {
 
   log(msg: string) {
     if (this._verbose) {
-      console.error("[neon update-platforms] " + msg);
+      console.error("[neon update] " + msg);
     }
   }
 

--- a/src/cli/src/print.ts
+++ b/src/cli/src/print.ts
@@ -1,6 +1,7 @@
 import commandLineUsage from 'command-line-usage';
 import chalk from 'chalk';
 import { CommandName, CommandStatics, commandFor, summaries } from './command.js';
+import { Topic, subcommandFor } from './commands/show.js';
 
 function pink(text: string): string {
   return chalk.bold.hex('#e75480')(text);
@@ -22,7 +23,7 @@ function purple(text: string): string {
   return chalk.bold.magentaBright(text);
 }
 
-function commandUsage(name: CommandName, command: CommandStatics): string {
+function commandUsage(name: string, command: CommandStatics): string {
   const sections = [
     {
       content: `${pink('Neon:')} ${name} - ${command.summary()}`,
@@ -68,6 +69,10 @@ function mainUsage(): string {
   ];
 
   return commandLineUsage(sections).trim();
+}
+
+export function printShowTopicUsage(topic: Topic) {
+  console.error(commandUsage(topic, subcommandFor(topic)));
 }
 
 export function printCommandUsage(name: CommandName) {

--- a/src/cli/src/print.ts
+++ b/src/cli/src/print.ts
@@ -26,7 +26,7 @@ function purple(text: string): string {
 function commandUsage(name: string, command: CommandStatics): string {
   const sections = [
     {
-      content: `${pink('Neon:')} ${name} - ${command.summary()}`,
+      content: `${pink('neon ' + name)} - ${command.summary()}`,
       raw: true
     },
     {
@@ -55,7 +55,7 @@ function commandUsage(name: string, command: CommandStatics): string {
 function mainUsage(): string {
   const sections = [
     {
-      content: `${pink('Neon:')} the npm packaging tool for Rust addons`,
+      content: `${pink('neon')} - manage and distribute Neon projects`,
       raw: true
     },
     {
@@ -72,7 +72,7 @@ function mainUsage(): string {
 }
 
 export function printShowTopicUsage(topic: Topic) {
-  console.error(commandUsage(topic, subcommandFor(topic)));
+  console.error(commandUsage("show " + topic, subcommandFor(topic)));
 }
 
 export function printCommandUsage(name: CommandName) {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -31,7 +31,7 @@
       "dependencies": {
         "@neon-rs/load": "^0.0.181",
         "@neon-rs/manifest": "^0.0.5",
-        "cargo-messages": "^0.1.65",
+        "cargo-messages": "^0.1.66",
         "chalk": "^5.2.0",
         "command-line-args": "^5.2.1",
         "command-line-commands": "^3.0.2",
@@ -57,19 +57,19 @@
         "typescript": "^5.0.4"
       },
       "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.1.65",
-        "@cargo-messages/darwin-arm64": "0.1.65",
-        "@cargo-messages/darwin-x64": "0.1.65",
-        "@cargo-messages/linux-arm-gnueabihf": "0.1.65",
-        "@cargo-messages/linux-x64-gnu": "0.1.65",
-        "@cargo-messages/win32-arm64-msvc": "0.1.65",
-        "@cargo-messages/win32-x64-msvc": "0.1.65"
+        "@cargo-messages/android-arm-eabi": "0.1.66",
+        "@cargo-messages/darwin-arm64": "0.1.66",
+        "@cargo-messages/darwin-x64": "0.1.66",
+        "@cargo-messages/linux-arm-gnueabihf": "0.1.66",
+        "@cargo-messages/linux-x64-gnu": "0.1.66",
+        "@cargo-messages/win32-arm64-msvc": "0.1.66",
+        "@cargo-messages/win32-x64-msvc": "0.1.66"
       }
     },
     "cli/node_modules/@cargo-messages/android-arm-eabi": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.1.65.tgz",
-      "integrity": "sha512-Pw+391Vw+enMTDUoyTUK9kvAGTgrMCO1H8FBr5d60VETi/Doy7YLszrMpYwYogklt5T+qvQg/Vf8Is1pXKjBTQ==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.1.66.tgz",
+      "integrity": "sha512-FH7bjqofQWt8ktUB91xSt63AfCZUmJUxu/ild3/OX7uCdGBwJ2vHXQppjnervEuYya7O5CoTZ+FNUhqVFMAkdw==",
       "cpu": [
         "arm"
       ],
@@ -79,9 +79,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/darwin-arm64": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.1.65.tgz",
-      "integrity": "sha512-huWhNtMRYxR7+JkLvmp2m3PRQbPkn96o0gK0s75oXzWopgVtz0zW/G4xMzwu/XSmCaw62T58jtJaqWzB+K1LOQ==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.1.66.tgz",
+      "integrity": "sha512-1eLV3JeCWAIAJ+Cy79oA475neGQU/nQgc0Y11tBJOHu5CDIU8+1zTfdRKRgA3PupqKgNmBJGM896+SXtdNE5YA==",
       "cpu": [
         "arm64"
       ],
@@ -91,9 +91,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/darwin-x64": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.1.65.tgz",
-      "integrity": "sha512-Ij/d6WZ9DqqJNkTwBR2k28GwucKRt7olKq+JmA56jqfON/RLAapqk8Pr8rDMOfK6LQJWgfljs6zV1Tw1bEI/SQ==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.1.66.tgz",
+      "integrity": "sha512-cfvcXvRL1MTE/Ny7ukmcv7ZFosXhOiEYn5btvfvxLtsKnO5ZIerUqGtRDhVp1YAUNQinhDdUQTSJNxzvvVWmwg==",
       "cpu": [
         "x64"
       ],
@@ -103,9 +103,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/linux-arm-gnueabihf": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.1.65.tgz",
-      "integrity": "sha512-QfnRMBArbaHhUMrTGt0ia/S53BFneTBvihjyvMXR8qJuwcJkyqM9kswVOvS3Q7pdlxZAOecsMmp7GrJYHB0pcw==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.1.66.tgz",
+      "integrity": "sha512-9TNknBFrxZrTRuDodiWJgI8iyKTw0KKIm9s89AgguR23hQaNmpm7Ziwdp4V0FCA7EOs5El47KAFDNFV/SgeeoA==",
       "cpu": [
         "arm"
       ],
@@ -115,9 +115,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/linux-x64-gnu": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.1.65.tgz",
-      "integrity": "sha512-dt3fclSW9LM3BskNg0e1ArgDU39jg/ei77b+ishHewe4pAnq+egd/6io6RrsssrjHpulVIhDw/XMK11CpAAkAw==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.1.66.tgz",
+      "integrity": "sha512-knFJIzGNco/onabi3pubuuikL/TR5y0IbS5lFq/wTNzijazFOU7r/ihBOewJlrlAuiWRl1nxueLXaiAwXWXDng==",
       "cpu": [
         "x64"
       ],
@@ -127,9 +127,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/win32-arm64-msvc": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.1.65.tgz",
-      "integrity": "sha512-x7ylxtuw6/NT8pJmMpMu3zr1w3qYQzBC2sFmNv80r/BTBK7zaLKd1QTBroL61mDZ0cbKwY8c/pI0bwIGJgTWug==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.1.66.tgz",
+      "integrity": "sha512-bORY5s7D7rgA//KfTNox1PxLWwmjNrIaPolHk4cAh9DnYDpehQncUNBCq1RlwuwhY28D8bqMUClPdDf/Gl45HQ==",
       "cpu": [
         "arm64"
       ],
@@ -139,9 +139,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/win32-x64-msvc": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.1.65.tgz",
-      "integrity": "sha512-nZFLlL1V6nW2fMu0j5eYM0gQSZt+oJezHxCe8B68YNQKG3bKjlH0/CfgxS3i0g742EA0t/pjyAbpX4lZPTtg0Q==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.1.66.tgz",
+      "integrity": "sha512-zgRYHP1VC+YeAZQ4aGfKpM7dFCyV2tB9O1zMfH99YC+VVwwRA69ZIOB/TtmQtMXkGLnuOC+4QPlD5VO5OI6+Qg==",
       "cpu": [
         "x64"
       ],
@@ -156,20 +156,20 @@
       "integrity": "sha512-teRPDgstiKQE91WsvnW4mAdTSEPUdi9a8b98IPVhm2R5MT1elzxeTFidP56JfqtzocZFYDetCwEcPB3xCIR4pg=="
     },
     "cli/node_modules/cargo-messages": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/cargo-messages/-/cargo-messages-0.1.65.tgz",
-      "integrity": "sha512-q21sWW2WrKCtRKZCXwZ1U/CvXbUSPr1TpHFAbasmgBUZ8SIbxeDS+R3s/+7lmSQhUAnam1TOWalk8ZN369JvdQ==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/cargo-messages/-/cargo-messages-0.1.66.tgz",
+      "integrity": "sha512-p0CZuaW9DJyTObd6fwvEkd8v8JNb3s8ECurfNBifO5+eHA28d87YiutgYh/FaTHmlOPTIPjEme6gefAusgjsvg==",
       "dependencies": {
         "@neon-rs/load": "^0.1.49"
       },
       "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.1.65",
-        "@cargo-messages/darwin-arm64": "0.1.65",
-        "@cargo-messages/darwin-x64": "0.1.65",
-        "@cargo-messages/linux-arm-gnueabihf": "0.1.65",
-        "@cargo-messages/linux-x64-gnu": "0.1.65",
-        "@cargo-messages/win32-arm64-msvc": "0.1.65",
-        "@cargo-messages/win32-x64-msvc": "0.1.65"
+        "@cargo-messages/android-arm-eabi": "0.1.66",
+        "@cargo-messages/darwin-arm64": "0.1.66",
+        "@cargo-messages/darwin-x64": "0.1.66",
+        "@cargo-messages/linux-arm-gnueabihf": "0.1.66",
+        "@cargo-messages/linux-x64-gnu": "0.1.66",
+        "@cargo-messages/win32-arm64-msvc": "0.1.66",
+        "@cargo-messages/win32-x64-msvc": "0.1.66"
       }
     },
     "cli/node_modules/cargo-messages/node_modules/@neon-rs/load": {


### PR DESCRIPTION
More ergonomic CLI command syntax:

- `neon add-platform` ==> `neon add`
- `neon update-platforms` ==> `neon update`
- `neon list-platforms` ==> `neon show platforms`
- `neon current-platform` ==> `neon show system`
- `neon ci` ==> `neon show ci`
- `neon preset` ==> `neon show preset`

<img width="732" alt="image" src="https://github.com/neon-bindings/neon-rs/assets/307871/33943def-0300-4c99-b219-3eb8ad5de8a1">

The previous commands should continue to be supported for backwards compatibility until the 0.2 release.