### PR TITLE
polish(manifest): pretty-print a singleton preset as a string

### DIFF
--- a/src/manifest/package.json
+++ b/src/manifest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@neon-rs/manifest",
   "private": false,
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "Library for working with Neon package configuration.",
   "exports": {
     ".": {

--- a/src/manifest/src/library/library.cts
+++ b/src/manifest/src/library/library.cts
@@ -28,6 +28,16 @@ function assertIsLibraryCfg(json: unknown): asserts json is LibraryCfg {
   }
 }
 
+function isEmptyFamily(family: PlatformFamily): boolean {
+  if (typeof family === 'string') {
+    return false;
+  }
+  if (Array.isArray(family)) {
+    return family.length === 0;
+  }
+  return Object.keys(family).length === 0;
+}
+
 type HasLibraryCfg = { neon: LibraryCfg };
 
 function assertHasLibraryCfg(json: object): asserts json is HasLibraryCfg {
@@ -165,15 +175,15 @@ export class LibraryManifest extends AbstractManifest {
       await this.addPlatforms(expandPlatformFamily(preset));
     }
 
-    else if (Array.isArray(platformsSrc)) {
-      platformsSrc.push(preset);
+    // Edge case: use the string shorthand source format for a single preset
+    else if (isEmptyFamily(platformsSrc)) {
+      this.cfg().platforms = preset;
       await this.addPlatforms(expandPlatformFamily(preset));
     }
 
-    // Edge case: an empty object can be treated like an empty array
-    else if (Object.keys(platformsSrc).length === 0) {
-      this.cfg().platforms = [];
-      await this.addPlatformPreset(preset);
+    else if (Array.isArray(platformsSrc)) {
+      platformsSrc.push(preset);
+      await this.addPlatforms(expandPlatformFamily(preset));
     }
 
     else {

--- a/src/manifest/src/test/manifest.cts
+++ b/src/manifest/src/test/manifest.cts
@@ -68,6 +68,22 @@ describe("simple manifest", () => {
     await testEmptyPlatforms(lib, 'empty-array-platforms', '0.2.42');
   });
 
+  it("uses string shorthand when adding a preset to an empty object", async () => {
+    const lib = await library('empty-object-platforms');
+    await lib.addPlatformPreset('common');
+    await lib.saveChanges(() => {});
+    const reloaded = await LibraryManifest.load(lib.dir);
+    assert.strictEqual(reloaded.cfg().platforms, 'common');
+  });
+
+  it("uses string shorthand when adding a preset to an empty array", async () => {
+    const lib = await library('empty-array-platforms');
+    await lib.addPlatformPreset('common');
+    await lib.saveChanges(() => {});
+    const reloaded = await LibraryManifest.load(lib.dir);
+    assert.strictEqual(reloaded.cfg().platforms, 'common');
+  });
+
   it("can update optionalDependencies", async () => {
     const lib = await library('empty-object-platforms');
     await lib.addNodePlatform('darwin-arm64');


### PR DESCRIPTION
Edge case for saving library manifest: when adding a single preset to an empty family, pretty-print as a single string (e.g., `'common'` instead of `['common']`).