### PR TITLE
fix(cli): Proper crate name normalization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,13 @@ jobs:
         shell: bash
         run: |
           echo "***** github.event:"
-          echo '${{ toJSON(github.event) }}'
+          cat <<GITHUB_EVENT_JSON
+          ${{toJSON(github.event)}}
+          GITHUB_EVENT_JSON
           echo "***** github.repository:"
-          echo '${{ toJSON(github.repository) }}'
+          cat <<GITHUB_REPOSITORY_JSON
+          ${{toJSON(github.repository)}}
+          GITHUB_REPOSITORY_JSON
           echo "***** github.head_ref:"
           echo 'ref: ${{ github.event_name == 'issue_comment' && github.head_ref }}'
           echo "***** github.event.repository.default_branch:"


### PR DESCRIPTION
This PR implements proper crate name normalization (#56 didn't fix it):

- the correct check is, `normalize(crateName) === normalize(target.name)`
- implement this in the Rust source of the older (currently unused) `CargoMessages` class
- implement this in the TS source of the `Dist` class of `@neon-rs/cli`