### PR TITLE
`neon dist`: use `copyArtifact` instead of `copyFile`

### DIFF
--- a/dist/cli/package.json
+++ b/dist/cli/package.json
@@ -27,12 +27,12 @@
   },
   "homepage": "https://github.com/dherman/neon-rs#readme",
   "optionalDependencies": {
-    "@cargo-messages/android-arm-eabi": "0.1.71",
-    "@cargo-messages/darwin-arm64": "0.1.71",
-    "@cargo-messages/darwin-x64": "0.1.71",
-    "@cargo-messages/linux-arm-gnueabihf": "0.1.71",
-    "@cargo-messages/linux-x64-gnu": "0.1.71",
-    "@cargo-messages/win32-arm64-msvc": "0.1.71",
-    "@cargo-messages/win32-x64-msvc": "0.1.71"
+    "@cargo-messages/android-arm-eabi": "0.1.72",
+    "@cargo-messages/darwin-arm64": "0.1.72",
+    "@cargo-messages/darwin-x64": "0.1.72",
+    "@cargo-messages/linux-arm-gnueabihf": "0.1.72",
+    "@cargo-messages/linux-x64-gnu": "0.1.72",
+    "@cargo-messages/win32-arm64-msvc": "0.1.72",
+    "@cargo-messages/win32-x64-msvc": "0.1.72"
   }
 }

--- a/dist/package-lock.json
+++ b/dist/package-lock.json
@@ -20,22 +20,22 @@
         "neon": "index.js"
       },
       "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.1.71",
-        "@cargo-messages/darwin-arm64": "0.1.71",
-        "@cargo-messages/darwin-x64": "0.1.71",
-        "@cargo-messages/linux-arm-gnueabihf": "0.1.71",
-        "@cargo-messages/linux-x64-gnu": "0.1.71",
-        "@cargo-messages/win32-arm64-msvc": "0.1.71",
-        "@cargo-messages/win32-x64-msvc": "0.1.71"
+        "@cargo-messages/android-arm-eabi": "0.1.72",
+        "@cargo-messages/darwin-arm64": "0.1.72",
+        "@cargo-messages/darwin-x64": "0.1.72",
+        "@cargo-messages/linux-arm-gnueabihf": "0.1.72",
+        "@cargo-messages/linux-x64-gnu": "0.1.72",
+        "@cargo-messages/win32-arm64-msvc": "0.1.72",
+        "@cargo-messages/win32-x64-msvc": "0.1.72"
       }
     },
     "install": {
       "version": "0.1.72"
     },
     "node_modules/@cargo-messages/android-arm-eabi": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.1.71.tgz",
-      "integrity": "sha512-QGpFhSvZ0tbEYc2Y9g95vTvAtlqAww2X/k6pSKkuk3yKlB2gi/aUTbM7VmTAZuKBJSYFhKLYr78bwkOC0SweDg==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.1.72.tgz",
+      "integrity": "sha512-gGZxIM1mj+Y5x+ULND6ZCNr7f70OJi9wDlycSK8hGONy9wrChN6JAIHryddC5cqcwlYAoQ6IDcDFElnhAYbybA==",
       "cpu": [
         "arm"
       ],
@@ -45,9 +45,9 @@
       ]
     },
     "node_modules/@cargo-messages/darwin-arm64": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.1.71.tgz",
-      "integrity": "sha512-lS0gJeQmsitFgt1e4vRDgPq2CUGPP7lXV2T4yztNwR1FtsS9rQa00e8UYNGDmQjl05CRhDFVcX0IswoshlAA6g==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.1.72.tgz",
+      "integrity": "sha512-EAzN5MLaXPljZKZDO5qR+aBs44eSq2ZbEnS7AI/FziE3MzeXbrGOS3fLba5+7yWPFXJyZolXzePm8N1EBv8ovg==",
       "cpu": [
         "arm64"
       ],
@@ -57,9 +57,9 @@
       ]
     },
     "node_modules/@cargo-messages/darwin-x64": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.1.71.tgz",
-      "integrity": "sha512-loSQ7G6SjKx/sd78qQqJQuepxrR2Nvx+/Vv4WXa+aeuFD5MwBoPPfgvz19T5eRmbLKzdd1S+ZBfg8xQXzHeKzw==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.1.72.tgz",
+      "integrity": "sha512-RLo6j8s3nYbjdd1LDct4wamfChyRit7zokUuxtIYCu9XOlltkN5vnj1vwnrPvoqCMZ/7CbbuHFwSTn9A71de/w==",
       "cpu": [
         "x64"
       ],
@@ -69,9 +69,9 @@
       ]
     },
     "node_modules/@cargo-messages/linux-arm-gnueabihf": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.1.71.tgz",
-      "integrity": "sha512-2lNiSjRLBXB1zgBOM39VR6FvLNovAj9duaMb3IAh6Uu3V3V8YS66oMDsBZwdN/5f2tivad2tJsaDu+nAjadyDA==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.1.72.tgz",
+      "integrity": "sha512-tHsRshuzfjrX6SDW3jg6al8vMNLTMgczGnVYl5RuBZf/yrAUuwe30KxA9ge6w6mW6Ox797DyBchzAc9OLgTgmQ==",
       "cpu": [
         "arm"
       ],
@@ -81,9 +81,9 @@
       ]
     },
     "node_modules/@cargo-messages/linux-x64-gnu": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.1.71.tgz",
-      "integrity": "sha512-diYf0bfNoaxuTw/jzPC4Ij8l4g8xKf9aFZOIeFNYqSu/vtfHkT0oEv4P2p6hMNjXhiSDI4FtTGqloEMpVGSKqg==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.1.72.tgz",
+      "integrity": "sha512-VGtL6CCnUbhsP4aYuBNT5kfrAL7o0qjrxw97a+ax13t+nJd26tVEEIKHMu5drvvS/Nm/hn7sLT8zMnnCv0pvHg==",
       "cpu": [
         "x64"
       ],
@@ -93,9 +93,9 @@
       ]
     },
     "node_modules/@cargo-messages/win32-arm64-msvc": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.1.71.tgz",
-      "integrity": "sha512-R1q/QVKlWmwPCvHcbAWI+SIdyFJwYheNiATd8OgRgtV0FJpayEfujA4SIJACCh4tp4bBWGrtGHoef+fFzXe4HA==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.1.72.tgz",
+      "integrity": "sha512-V93Cgz39K+yqa3MveNbhh29pYCp8izK5uEavjPoxlNxAbsMCWH+s0verGDdUcfGxjR1H2V7oZ4FszPqR2SqMRQ==",
       "cpu": [
         "arm64"
       ],
@@ -105,9 +105,9 @@
       ]
     },
     "node_modules/@cargo-messages/win32-x64-msvc": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.1.71.tgz",
-      "integrity": "sha512-hoH775tj9Q9P+znsDGP3iT4mQwd+5lxkS+MfwJ1br13/EXaWX/aZ6T5cU+5UEI0qTzRBl6gC9pkhMaJ+TrZ42A==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.1.72.tgz",
+      "integrity": "sha512-knz3uSrO0OSbq3U5VWfCY8FB4NsM43BOWLZ7x4sfaMOC1XWv+IyvDdkLe6DhJx8KUw46KIAimYs9YROrp6l46Q==",
       "cpu": [
         "x64"
       ],

--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -56,6 +56,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
+    "@neon-rs/artifact": "^0.1.0",
     "@neon-rs/load": "^0.0.181",
     "@neon-rs/manifest": "^0.0.5",
     "cargo-messages": "^0.1.71",

--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -59,7 +59,7 @@
     "@neon-rs/artifact": "^0.1.0",
     "@neon-rs/load": "^0.0.181",
     "@neon-rs/manifest": "^0.0.5",
-    "cargo-messages": "^0.1.71",
+    "cargo-messages": "^0.1.72",
     "chalk": "^5.2.0",
     "command-line-args": "^5.2.1",
     "command-line-commands": "^3.0.2",
@@ -70,12 +70,12 @@
     "temp": "^0.9.4"
   },
   "optionalDependencies": {
-    "@cargo-messages/android-arm-eabi": "0.1.71",
-    "@cargo-messages/darwin-arm64": "0.1.71",
-    "@cargo-messages/darwin-x64": "0.1.71",
-    "@cargo-messages/linux-arm-gnueabihf": "0.1.71",
-    "@cargo-messages/linux-x64-gnu": "0.1.71",
-    "@cargo-messages/win32-arm64-msvc": "0.1.71",
-    "@cargo-messages/win32-x64-msvc": "0.1.71"
+    "@cargo-messages/android-arm-eabi": "0.1.72",
+    "@cargo-messages/darwin-arm64": "0.1.72",
+    "@cargo-messages/darwin-x64": "0.1.72",
+    "@cargo-messages/linux-arm-gnueabihf": "0.1.72",
+    "@cargo-messages/linux-x64-gnu": "0.1.72",
+    "@cargo-messages/win32-arm64-msvc": "0.1.72",
+    "@cargo-messages/win32-x64-msvc": "0.1.72"
   }
 }

--- a/src/cli/src/commands/dist.ts
+++ b/src/cli/src/commands/dist.ts
@@ -1,10 +1,10 @@
 import { createReadStream } from 'node:fs';
-import { copyFile } from 'node:fs/promises';
 import commandLineArgs from 'command-line-args';
 import { Command, CommandDetail, CommandSection } from '../command.js';
 import { CargoReader } from 'cargo-messages';
 import { LibraryManifest } from '@neon-rs/manifest';
 import { assertIsNodePlatform } from '@neon-rs/manifest/platform';
+import { copyArtifact } from '@neon-rs/artifact';
 
 // Starting around Rust 1.78 or 1.79, cargo will begin normalizing
 // crate names in the JSON output, so to support both old and new
@@ -180,7 +180,6 @@ export default class Dist implements Command {
     this.log(`output type = ${option}`);
     this.log(`output file = ${path}`);
 
-    // FIXME: needs all the logic of cargo-cp-artifact (timestamp check, M1 workaround, async, errors)
-    await copyFile(file, path);
+    await copyArtifact(file, path);
   }
 }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -29,6 +29,7 @@
       "version": "0.1.72",
       "license": "MIT",
       "dependencies": {
+        "@neon-rs/artifact": "^0.1.0",
         "@neon-rs/load": "^0.0.181",
         "@neon-rs/manifest": "^0.0.5",
         "cargo-messages": "^0.1.71",
@@ -1047,6 +1048,11 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@neon-rs/artifact": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@neon-rs/artifact/-/artifact-0.1.0.tgz",
+      "integrity": "sha512-GdrnE9PNGTJYKNQsCTFgi2oRmm6Uexp0/9JcuhRIYeOJKnEgDe/AWOOY+4CfG95Eolf4/EKEPcan/Sb22o47Ug=="
     },
     "node_modules/@neon-rs/cli": {
       "resolved": "cli",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -32,7 +32,7 @@
         "@neon-rs/artifact": "^0.1.0",
         "@neon-rs/load": "^0.0.181",
         "@neon-rs/manifest": "^0.0.5",
-        "cargo-messages": "^0.1.71",
+        "cargo-messages": "^0.1.72",
         "chalk": "^5.2.0",
         "command-line-args": "^5.2.1",
         "command-line-commands": "^3.0.2",
@@ -62,19 +62,19 @@
         "typescript": "^5.0.4"
       },
       "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.1.71",
-        "@cargo-messages/darwin-arm64": "0.1.71",
-        "@cargo-messages/darwin-x64": "0.1.71",
-        "@cargo-messages/linux-arm-gnueabihf": "0.1.71",
-        "@cargo-messages/linux-x64-gnu": "0.1.71",
-        "@cargo-messages/win32-arm64-msvc": "0.1.71",
-        "@cargo-messages/win32-x64-msvc": "0.1.71"
+        "@cargo-messages/android-arm-eabi": "0.1.72",
+        "@cargo-messages/darwin-arm64": "0.1.72",
+        "@cargo-messages/darwin-x64": "0.1.72",
+        "@cargo-messages/linux-arm-gnueabihf": "0.1.72",
+        "@cargo-messages/linux-x64-gnu": "0.1.72",
+        "@cargo-messages/win32-arm64-msvc": "0.1.72",
+        "@cargo-messages/win32-x64-msvc": "0.1.72"
       }
     },
     "cli/node_modules/@cargo-messages/android-arm-eabi": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.1.71.tgz",
-      "integrity": "sha512-QGpFhSvZ0tbEYc2Y9g95vTvAtlqAww2X/k6pSKkuk3yKlB2gi/aUTbM7VmTAZuKBJSYFhKLYr78bwkOC0SweDg==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/android-arm-eabi/-/android-arm-eabi-0.1.72.tgz",
+      "integrity": "sha512-gGZxIM1mj+Y5x+ULND6ZCNr7f70OJi9wDlycSK8hGONy9wrChN6JAIHryddC5cqcwlYAoQ6IDcDFElnhAYbybA==",
       "cpu": [
         "arm"
       ],
@@ -84,9 +84,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/darwin-arm64": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.1.71.tgz",
-      "integrity": "sha512-lS0gJeQmsitFgt1e4vRDgPq2CUGPP7lXV2T4yztNwR1FtsS9rQa00e8UYNGDmQjl05CRhDFVcX0IswoshlAA6g==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-arm64/-/darwin-arm64-0.1.72.tgz",
+      "integrity": "sha512-EAzN5MLaXPljZKZDO5qR+aBs44eSq2ZbEnS7AI/FziE3MzeXbrGOS3fLba5+7yWPFXJyZolXzePm8N1EBv8ovg==",
       "cpu": [
         "arm64"
       ],
@@ -96,9 +96,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/darwin-x64": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.1.71.tgz",
-      "integrity": "sha512-loSQ7G6SjKx/sd78qQqJQuepxrR2Nvx+/Vv4WXa+aeuFD5MwBoPPfgvz19T5eRmbLKzdd1S+ZBfg8xQXzHeKzw==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/darwin-x64/-/darwin-x64-0.1.72.tgz",
+      "integrity": "sha512-RLo6j8s3nYbjdd1LDct4wamfChyRit7zokUuxtIYCu9XOlltkN5vnj1vwnrPvoqCMZ/7CbbuHFwSTn9A71de/w==",
       "cpu": [
         "x64"
       ],
@@ -108,9 +108,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/linux-arm-gnueabihf": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.1.71.tgz",
-      "integrity": "sha512-2lNiSjRLBXB1zgBOM39VR6FvLNovAj9duaMb3IAh6Uu3V3V8YS66oMDsBZwdN/5f2tivad2tJsaDu+nAjadyDA==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.1.72.tgz",
+      "integrity": "sha512-tHsRshuzfjrX6SDW3jg6al8vMNLTMgczGnVYl5RuBZf/yrAUuwe30KxA9ge6w6mW6Ox797DyBchzAc9OLgTgmQ==",
       "cpu": [
         "arm"
       ],
@@ -120,9 +120,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/linux-x64-gnu": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.1.71.tgz",
-      "integrity": "sha512-diYf0bfNoaxuTw/jzPC4Ij8l4g8xKf9aFZOIeFNYqSu/vtfHkT0oEv4P2p6hMNjXhiSDI4FtTGqloEMpVGSKqg==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/linux-x64-gnu/-/linux-x64-gnu-0.1.72.tgz",
+      "integrity": "sha512-VGtL6CCnUbhsP4aYuBNT5kfrAL7o0qjrxw97a+ax13t+nJd26tVEEIKHMu5drvvS/Nm/hn7sLT8zMnnCv0pvHg==",
       "cpu": [
         "x64"
       ],
@@ -132,9 +132,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/win32-arm64-msvc": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.1.71.tgz",
-      "integrity": "sha512-R1q/QVKlWmwPCvHcbAWI+SIdyFJwYheNiATd8OgRgtV0FJpayEfujA4SIJACCh4tp4bBWGrtGHoef+fFzXe4HA==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-arm64-msvc/-/win32-arm64-msvc-0.1.72.tgz",
+      "integrity": "sha512-V93Cgz39K+yqa3MveNbhh29pYCp8izK5uEavjPoxlNxAbsMCWH+s0verGDdUcfGxjR1H2V7oZ4FszPqR2SqMRQ==",
       "cpu": [
         "arm64"
       ],
@@ -144,9 +144,9 @@
       ]
     },
     "cli/node_modules/@cargo-messages/win32-x64-msvc": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.1.71.tgz",
-      "integrity": "sha512-hoH775tj9Q9P+znsDGP3iT4mQwd+5lxkS+MfwJ1br13/EXaWX/aZ6T5cU+5UEI0qTzRBl6gC9pkhMaJ+TrZ42A==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/@cargo-messages/win32-x64-msvc/-/win32-x64-msvc-0.1.72.tgz",
+      "integrity": "sha512-knz3uSrO0OSbq3U5VWfCY8FB4NsM43BOWLZ7x4sfaMOC1XWv+IyvDdkLe6DhJx8KUw46KIAimYs9YROrp6l46Q==",
       "cpu": [
         "x64"
       ],
@@ -161,20 +161,20 @@
       "integrity": "sha512-teRPDgstiKQE91WsvnW4mAdTSEPUdi9a8b98IPVhm2R5MT1elzxeTFidP56JfqtzocZFYDetCwEcPB3xCIR4pg=="
     },
     "cli/node_modules/cargo-messages": {
-      "version": "0.1.71",
-      "resolved": "https://registry.npmjs.org/cargo-messages/-/cargo-messages-0.1.71.tgz",
-      "integrity": "sha512-B1nVryG38ERAEoCmEiV+HsFVv4vs+y5j87FtIIplp/qWAV0O/Q0KrB9JnXGHMn7sbGV/AJozHcrcOfDJ2ZWXCQ==",
+      "version": "0.1.72",
+      "resolved": "https://registry.npmjs.org/cargo-messages/-/cargo-messages-0.1.72.tgz",
+      "integrity": "sha512-wGlHRUTJmu0CXksYdIMyO9buCeatvJUe0ofOESGl9weSGY6Vm5XZXsZX4Oduwg7WhR4n9IG2/hHj8HJDilZOJg==",
       "dependencies": {
         "@neon-rs/load": "^0.1.49"
       },
       "optionalDependencies": {
-        "@cargo-messages/android-arm-eabi": "0.1.71",
-        "@cargo-messages/darwin-arm64": "0.1.71",
-        "@cargo-messages/darwin-x64": "0.1.71",
-        "@cargo-messages/linux-arm-gnueabihf": "0.1.71",
-        "@cargo-messages/linux-x64-gnu": "0.1.71",
-        "@cargo-messages/win32-arm64-msvc": "0.1.71",
-        "@cargo-messages/win32-x64-msvc": "0.1.71"
+        "@cargo-messages/android-arm-eabi": "0.1.72",
+        "@cargo-messages/darwin-arm64": "0.1.72",
+        "@cargo-messages/darwin-x64": "0.1.72",
+        "@cargo-messages/linux-arm-gnueabihf": "0.1.72",
+        "@cargo-messages/linux-x64-gnu": "0.1.72",
+        "@cargo-messages/win32-arm64-msvc": "0.1.72",
+        "@cargo-messages/win32-x64-msvc": "0.1.72"
       }
     },
     "cli/node_modules/cargo-messages/node_modules/@neon-rs/load": {


### PR DESCRIPTION
Change `neon dist` to use `copyArtifact` from @neon-rs/artifact instead of `fs.copyFile`.