### PR TITLE
Add linux-arm64-gnu to prebuilt binaries

### DIFF
--- a/pkgs/cargo-messages/lib/load.cjs
+++ b/pkgs/cargo-messages/lib/load.cjs
@@ -6,5 +6,6 @@ module.exports = require('@neon-rs/load').proxy({
   'darwin-arm64': () => require('@cargo-messages/darwin-arm64'),
   'linux-x64-gnu': () => require('@cargo-messages/linux-x64-gnu'),
   'linux-arm-gnueabihf': () => require('@cargo-messages/linux-arm-gnueabihf'),
+  'linux-arm64-gnu': () => require('@cargo-messages/linux-arm64-gnu'),
   'android-arm-eabi': () => require('@cargo-messages/android-arm-eabi')
 });

--- a/pkgs/cargo-messages/platforms/linux-arm64-gnu/README.md
+++ b/pkgs/cargo-messages/platforms/linux-arm64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@cargo-messages/linux-arm64-gnu`
+
+Prebuilt binary package for `cargo-messages` on `linux-arm64-gnu`.

--- a/pkgs/cargo-messages/platforms/linux-arm64-gnu/package.json
+++ b/pkgs/cargo-messages/platforms/linux-arm64-gnu/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@cargo-messages/linux-arm64-gnu",
+  "description": "Prebuilt binary package for `cargo-messages` on `linux-arm64-gnu`.",
+  "version": "0.1.73",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "index.node",
+  "files": [
+    "index.node"
+  ],
+  "author": "David Herman <david.herman@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dherman/neon-rs.git"
+  },
+  "keywords": [
+    "Rust",
+    "Neon"
+  ],
+  "bugs": {
+    "url": "https://github.com/dherman/neon-rs/issues"
+  },
+  "homepage": "https://github.com/dherman/neon-rs#readme",
+  "license": "MIT",
+  "neon": {
+    "type": "binary",
+    "rust": "aarch64-unknown-linux-gnu",
+    "node": "linux-arm64-gnu",
+    "os": "linux",
+    "arch": "arm64",
+    "abi": "gnu"
+  }
+}

--- a/src/cli/package.json
+++ b/src/cli/package.json
@@ -74,6 +74,7 @@
     "@cargo-messages/darwin-arm64": "0.1.72",
     "@cargo-messages/darwin-x64": "0.1.72",
     "@cargo-messages/linux-arm-gnueabihf": "0.1.72",
+    "@cargo-messages/linux-arm64-gnu": "0.1.72",
     "@cargo-messages/linux-x64-gnu": "0.1.72",
     "@cargo-messages/win32-arm64-msvc": "0.1.72",
     "@cargo-messages/win32-x64-msvc": "0.1.72"

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -66,6 +66,7 @@
         "@cargo-messages/darwin-arm64": "0.1.72",
         "@cargo-messages/darwin-x64": "0.1.72",
         "@cargo-messages/linux-arm-gnueabihf": "0.1.72",
+        "@cargo-messages/linux-arm64-gnu": "0.1.72",
         "@cargo-messages/linux-x64-gnu": "0.1.72",
         "@cargo-messages/win32-arm64-msvc": "0.1.72",
         "@cargo-messages/win32-x64-msvc": "0.1.72"

--- a/test/integration/sniff-bytes/platforms/linux-arm64-gnu/README.md
+++ b/test/integration/sniff-bytes/platforms/linux-arm64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@sniff-bytes/linux-arm64-gnu`
+
+Prebuilt binary package for `@neon-integration-tests/sniff-bytes` on `linux-arm64-gnu`.

--- a/test/integration/sniff-bytes/platforms/linux-arm64-gnu/package.json
+++ b/test/integration/sniff-bytes/platforms/linux-arm64-gnu/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@sniff-bytes/linux-arm64-gnu",
+  "description": "Prebuilt binary package for `@neon-integration-tests/sniff-bytes` on `linux-arm64-gnu`.",
+  "version": "1.0.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "index.node",
+  "files": [
+    "index.node"
+  ],
+  "neon": {
+    "type": "binary",
+    "rust": "aarch64-unknown-linux-gnu",
+    "node": "linux-arm64-gnu",
+    "os": "linux",
+    "arch": "arm64",
+    "abi": "gnu"
+  },
+  "license": "MIT"
+}

--- a/test/lint/check-versions.sh
+++ b/test/lint/check-versions.sh
@@ -19,7 +19,7 @@ echo "Expected manifest version: $expected"
 dist_dirs=(dist dist/cli dist/install)
 pkgs_dirs=(pkgs pkgs/cargo-messages pkgs/load)
 cmbin=pkgs/cargo-messages/platforms
-bin_dirs=($cmbin/android-arm-eabi $cmbin/darwin-arm64 $cmbin/darwin-x64 $cmbin/linux-arm-gnueabihf $cmbin/linux-x64-gnu $cmbin/win32-arm64-msvc $cmbin/win32-x64-msvc)
+bin_dirs=($cmbin/android-arm-eabi $cmbin/darwin-arm64 $cmbin/darwin-x64 $cmbin/linux-arm-gnueabihf $cmbin/linux-arm64-gnu $cmbin/linux-x64-gnu $cmbin/win32-arm64-msvc $cmbin/win32-x64-msvc)
 src_dirs=(src src/cli src/install)
 for d in ${dist_dirs[@]} ${pkgs_dirs[@]} ${bin_dirs[@]} ${src_dirs[@]} ; do
   actual=$(jq -r .version $d/package.json)


### PR DESCRIPTION
It's not clear to me where/how Github or the release process itself is defining which architectures to build against?

Thread: https://rust-bindings.slack.com/archives/C0H978T55/p1723665669205089