### PR TITLE
Add `linux-arm64-gnu` to the `desktop` preset

### DIFF
--- a/src/manifest/data/preset.json
+++ b/src/manifest/data/preset.json
@@ -14,7 +14,8 @@
     "win32-x64-msvc": "x86_64-pc-windows-msvc",
     "darwin-x64": "x86_64-apple-darwin",
     "darwin-arm64": "aarch64-apple-darwin",
-    "linux-x64-gnu": "x86_64-unknown-linux-gnu"
+    "linux-x64-gnu": "x86_64-unknown-linux-gnu",
+    "linux-arm64-gnu": "aarch64-unknown-linux-gnu"
   },
   "mobile": {
     "win32-arm64-msvc": "aarch64-pc-windows-msvc",

--- a/src/manifest/package.json
+++ b/src/manifest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@neon-rs/manifest",
   "private": false,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Library for working with Neon package configuration.",
   "exports": {
     ".": {


### PR DESCRIPTION
Given that [GitHub is even offering arm64 linux runners now](https://github.blog/news-insights/product-news/arm64-on-github-actions-powering-faster-more-efficient-build-systems/), it's safe to say arm64 linux is a common case.

Support for arm64 linux was added in #63. This PR makes it a default member of the `"desktop"` preset.