### PR TITLE
Add `prefix` field in `neon.library` config

### DIFF
--- a/src/manifest/fixtures/empty-platforms-with-prefix/package.json
+++ b/src/manifest/fixtures/empty-platforms-with-prefix/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "empty-platforms-with-prefix",
+  "private": false,
+  "version": "0.1.17",
+  "description": "A simple Neon library with a prefix and no platforms.",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./types/index.d.mts",
+        "default": "./lib/index.mjs"
+      },
+      "require": {
+        "types": "./types/index.d.cts",
+        "default": "./lib/index.cjs"
+      }
+    }
+  },
+  "types": "./types/index.d.cts",
+  "main": "./lib/index.cjs",
+  "files": [
+    "lib/index.cjs",
+    "lib/load.cjs",
+    "lib/index.mjs",
+    "types/index.d.cts",
+    "types/index.d.mts"
+  ],
+  "scripts": {
+    "test": "cargo test",
+    "cargo-build": "cargo build --message-format=json > cargo.log",
+    "cross-build": "cross build --message-format=json > cross.log",
+    "postcargo-build": "neon dist -v < cargo.log",
+    "postcross-build": "neon dist -v -m /target < cross.log",
+    "debug": "npm run cargo-build --",
+    "build": "npm run cargo-build -- --release",
+    "cross": "npm run cross-build -- --release",
+    "prepack": "neon update-platforms -v 2>update-platforms.log",
+    "version": "neon bump -v --binaries platforms"
+  },
+  "author": "David Herman <david.herman@gmail.com>",
+  "license": "MIT",
+  "devDependencies": {
+    "@neon-rs/cli": "^0.0.186"
+  },
+  "dependencies": {
+    "@neon-rs/load": "^0.0.186"
+  },
+  "neon": {
+    "type": "library",
+    "org": "@dherman",
+    "prefix": "empty-platforms-with-prefix-",
+    "platforms": {},
+    "load": "./lib/load.cjs"
+  }
+}

--- a/src/manifest/package.json
+++ b/src/manifest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@neon-rs/manifest",
   "private": false,
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Library for working with Neon package configuration.",
   "exports": {
     ".": {

--- a/src/manifest/src/cache/npm/npm.cts
+++ b/src/manifest/src/cache/npm/npm.cts
@@ -111,7 +111,7 @@ export class NPMCacheCfg implements CacheCfg {
               [],
               js.callExpression(
                 js.identifier('require'),
-                [js.literal(`${cfg.org}/${platform}`)]
+                [js.literal(`${cfg.org}/${cfg.prefix ?? ''}${platform}`)]
               )
             )
           );
@@ -123,7 +123,7 @@ export class NPMCacheCfg implements CacheCfg {
 
   packageNames(): string[] {
     const cfg = this.manifest.cfg();
-    return Object.keys(this.manifest.allPlatforms()).map(key => `${cfg.org}/${key}`);
+    return Object.keys(this.manifest.allPlatforms()).map(key => `${cfg.org}/${cfg.prefix ?? ''}${key}`);
   }
 
   updatePlatforms(lib: LibraryManifest): boolean {

--- a/src/manifest/src/library/library.cts
+++ b/src/manifest/src/library/library.cts
@@ -8,6 +8,7 @@ import { NPMCacheCfg } from "../cache/npm/npm.cjs";
 export interface LibraryCfg {
   type: "library";
   org: string;
+  prefix?: string;
   platforms: PlatformFamily;
   load?: string;
 }
@@ -24,6 +25,11 @@ function assertIsLibraryCfg(json: unknown): asserts json is LibraryCfg {
   if ('load' in json) {
     if (typeof json.load !== 'string' && typeof json.load !== 'undefined') {
       throw new TypeError(`expected "neon.load" to be a string, found ${json.load}`);
+    }
+  }
+  if ('prefix' in json) {
+    if (typeof json.prefix !== 'string' && typeof json.prefix !== 'undefined') {
+      throw new TypeError(`expected "neon.prefix" to be a string, found ${json.prefix}`);
     }
   }
 }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "workspaces": [
         "cli",
-        "install"
+        "install",
+        "manifest"
       ],
       "dependencies": {
         "cargo-messages": "0.0.168",
@@ -163,6 +164,14 @@
       "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.181.tgz",
       "integrity": "sha512-teRPDgstiKQE91WsvnW4mAdTSEPUdi9a8b98IPVhm2R5MT1elzxeTFidP56JfqtzocZFYDetCwEcPB3xCIR4pg=="
     },
+    "cli/node_modules/@neon-rs/manifest": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@neon-rs/manifest/-/manifest-0.1.3.tgz",
+      "integrity": "sha512-YeIpXbSMtmYqydyFsJUdRGWzLJjpMnF1Q+mWxDlWqid+GZpJX3C3P2QYpBMvoHh7Et8sqQhO31LA+pUDozuq0w==",
+      "dependencies": {
+        "jscodeshift": "^0.15.1"
+      }
+    },
     "cli/node_modules/cargo-messages": {
       "version": "0.1.80",
       "resolved": "https://registry.npmjs.org/cargo-messages/-/cargo-messages-0.1.80.tgz",
@@ -200,6 +209,108 @@
         "@vercel/ncc": "^0.36.1",
         "crlf": "^1.1.1",
         "typescript": "^5.0.4"
+      }
+    },
+    "manifest": {
+      "version": "0.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "jscodeshift": "^0.15.1"
+      },
+      "devDependencies": {
+        "@tsconfig/node16": "^16.1.1",
+        "@types/chai": "^4.3.12",
+        "@types/jscodeshift": "^0.11.11",
+        "@types/mocha": "^10.0.6",
+        "@types/node": "^20.11.10",
+        "chai": "^4.4.1",
+        "create-temp-directory": "^2.4.0",
+        "mocha": "^10.3.0",
+        "typescript": "^5.3.3"
+      }
+    },
+    "manifest/node_modules/@tsconfig/node16": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.3.tgz",
+      "integrity": "sha512-9nTOUBn+EMKO6rtSZJk+DcqsfgtlERGT9XPJ5PRj/HNENPCBY1yu/JEj5wT6GLtbCLBO2k46SeXDaY0pjMqypw==",
+      "dev": true
+    },
+    "manifest/node_modules/@types/node": {
+      "version": "20.17.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.6.tgz",
+      "integrity": "sha512-VEI7OdvK2wP7XHnsuXbAJnEpEkF6NjSN45QJlL4VGqZSXsnicpesdTWsg9RISeSdYd3yeRj/y3k5KGjUXYnFwQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "manifest/node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "manifest/node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "manifest/node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "manifest/node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "manifest/node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "manifest/node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@75lb/deep-merge": {
@@ -1106,12 +1217,8 @@
       "integrity": "sha512-zRkipoCMyu5eFdusb5DOcId/8zC/6xtM9+cM1E93AWAQvlEX2+PqFiltz6Fk57f6iZ6ASWrpdyqlzzGUHS9pbw=="
     },
     "node_modules/@neon-rs/manifest": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@neon-rs/manifest/-/manifest-0.1.3.tgz",
-      "integrity": "sha512-YeIpXbSMtmYqydyFsJUdRGWzLJjpMnF1Q+mWxDlWqid+GZpJX3C3P2QYpBMvoHh7Et8sqQhO31LA+pUDozuq0w==",
-      "dependencies": {
-        "jscodeshift": "^0.15.1"
-      }
+      "resolved": "manifest",
+      "link": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
@@ -1669,6 +1776,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+    },
+    "node_modules/create-temp-directory": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/create-temp-directory/-/create-temp-directory-2.4.0.tgz",
+      "integrity": "sha512-5aaU5XNkRKZTBw9tfnMiFh84Fo20+YIT+BcKPFwUHKYgBWwu7eY6AwJR8NwAekzu1H/ABXLhy4zJITHWJgFiHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/crlf": {
       "version": "1.1.1",
@@ -3348,10 +3464,19 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3368,6 +3493,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",

--- a/src/package.json
+++ b/src/package.json
@@ -5,14 +5,16 @@
   "version": "0.1.81",
   "workspaces": [
     "cli",
-    "install"
+    "install",
+    "manifest"
   ],
   "author": "Dave Herman <david.herman@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "dist": "npm run dist:cli && npm run dist:install",
+    "dist": "npm run dist:cli && npm run dist:install && npm run dist:manifest",
     "dist:cli": "cd cli && npm run dist",
     "dist:install": "cd install && npm run dist",
+    "dist:manifest": "cd manifest && npm run dist",
     "version": "node ../dist/cli bump -v --workspaces"
   },
   "dependencies": {


### PR DESCRIPTION
This PR adds support in `@neon-rs/manifest` for optional prefixes in npm prebuild package names.

Details:
- update optional `{ neon: { type: "library", prefix?: string, ... } }` field to package.json
- update codegen of load.cts to load package name with prefix if needed
