### PR TITLE
bugfix(@neon-rs/manifest): include prefix when creating binary package

### DIFF
--- a/src/manifest/package.json
+++ b/src/manifest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@neon-rs/manifest",
   "private": false,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Library for working with Neon package configuration.",
   "exports": {
     ".": {

--- a/src/manifest/src/cache/npm/package.cts
+++ b/src/manifest/src/cache/npm/package.cts
@@ -83,7 +83,7 @@ export class BinaryPackage {
     const targetInfo = describeTarget(rust);
     const libraryManifest = cacheCfg.manifest;
     const org = libraryManifest.cfg().org;
-    const name = `${org}/${node}`;
+    const name = `${org}/${cacheCfg.manifest.cfg().prefix ?? ''}${node}`;
     const json: any = {
       name,
       description: `Prebuilt binary package for \`${libraryManifest.name}\` on \`${targetInfo.node}\`.`,

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -213,7 +213,7 @@
     },
     "manifest": {
       "name": "@neon-rs/manifest",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "jscodeshift": "^0.15.1"


### PR DESCRIPTION
bugfix in @neon-rs/manifest: creating a binary package needs to include the optional prefix